### PR TITLE
[codex] Add IPMD VQVAE temporal latent learner

### DIFF
--- a/docs/vqvae_skill_report.md
+++ b/docs/vqvae_skill_report.md
@@ -1,0 +1,281 @@
+# IPMD + VQ-VAE Skill Codebook for Hierarchical Imitation
+
+Technical report. Branch `vqvae-impl` in both `RLOpt/` and `IsaacLab-Imitation/`.
+
+## 1. Goal
+
+Replace the current single-step deterministic latent encoder in IPMD with a
+**windowed VQ-VAE** so the latent command becomes a **discrete skill code**
+held across many env steps. This sets up a hierarchical control stack:
+
+- **Low-level (LL) policy** — current IPMD actor; conditions on a code embedding.
+- **High-level (HL) planner** — separate module (future work) that picks codes
+  from the codebook every `code_period` steps. Standard categorical policy /
+  autoregressive transformer over skill tokens.
+
+The new latent learner (`patch_vqvae`) is a drop-in alternative to the existing
+`patch_autoencoder` and lives behind a config flag.
+
+## 2. Background
+
+### 2.1 Why a window
+
+Single-frame posterior conflates pose with skill. A window of expert states
+forces the encoder to compress *temporally extended behavior* (subskill,
+phrase). The IsaacLab-Imitation env already exposes window observations via
+`expert_window/expert_motion`, `expert_window/expert_anchor_pos_b`,
+`expert_window/expert_anchor_ori_b` (built by
+`_build_expert_window_terms` in `imitation_rl_env.py`). Window length =
+`latent_patch_past_steps + 1 + latent_patch_future_steps`.
+
+### 2.2 Why discrete latents (VQ over VAE)
+
+For HL planning a categorical action space simplifies everything: BC = cross-
+entropy on tokens, RL = categorical policy, transformers/LLMs slot in
+naturally. Continuous latent regression is harder and less composable.
+
+### 2.3 Quantizer choices implemented
+
+| Quantizer | Codebook params | Collapse risk | Aux loss | Capacity |
+|---|---|---|---|---|
+| **FSQ** (default) | none (fixed grid) | none | none | ∏ levels |
+| **VQ-EMA** | learned + EMA | medium | commitment | K |
+| **Gumbel-Softmax** | learned embedding + logits | medium | KL-to-uniform + entropy | K |
+
+- **FSQ** (Mentzer 2023): per-dim scalar quantization on a fixed grid. No
+  codebook, no aux loss, no collapse. Output dim is small (5 by default ⇒
+  12 800 effective codes); we project to `latent_dim` with a small linear.
+- **VQ-EMA** (van den Oord + DALL·E line): nearest-neighbor on a learned
+  codebook, EMA cluster updates, commitment loss, k-means init, dead-code
+  revival.
+- **Gumbel-Softmax**: encoder emits logits over the codebook, sample with
+  Gumbel noise, optional straight-through hard forward. Provides true reparam
+  gradients; supports KL-to-uniform regularizer + marginal-usage entropy bonus
+  to prevent collapse. Familiar to the lab; useful as a backup / ablation.
+
+### 2.4 Why a code period
+
+A code per env step turns the HL planner into a high-frequency controller and
+loses the "skill" abstraction. We hold one sampled code per env for
+`code_period` steps; the encoder's window summarizes the upcoming `K` steps,
+and the HL planner replans only at chunk boundaries (~0.6 s @ 50 Hz with
+period 30). Aligns with classical *options*.
+
+## 3. Architecture
+
+```
+expert window x_{t-P:t}         ┐
+   ↓ encoder (MLP)              │ training only
+   z_e ∈ R^d                    │
+   ↓ quantizer (FSQ|VQ|Gumbel)  │
+   z_q, code_id                 │
+   ├──► decoder ──► x̂           │ recon loss → MSE(x̂, x)
+   └──► action_decoder ──► â    │ optional MSE(â, expert_action)
+   ↓ project (linear if needed) │
+   latent_dim embedding         ┘  ↑ also published at rollout time
+
+rollout (collector):
+   posterior obs (expert_window/*) ──► encode ──► quantize ──► code embedding
+   held for `code_period` env steps per env, then re-encode + re-quantize.
+```
+
+### 3.1 Pluggable in IPMD
+
+- All work lives in the `BaseLatentLearner` interface. IPMD code path
+  unchanged except the posterior branch in `_inject_latent_command`, which now
+  dispatches to `infer_collector_latents` if the learner exposes it
+  (`patch_vqvae` does, `patch_autoencoder` does not). All other learners
+  unaffected.
+
+## 4. Files changed
+
+### 4.1 RLOpt (worktree `RLOpt-vqvae`, branch `vqvae-impl`)
+
+- `rlopt/agent/imitation/latent_learning.py`
+  - `FSQQuantizer`, `EMAVQQuantizer`, `GumbelQuantizer` (new modules).
+  - `PatchVQVAELatentLearner` (new learner), registered key `"patch_vqvae"`.
+  - Diagnostic metrics: codebook perplexity, dead-code count, recon MSE,
+    action-recon MSE, commit loss, gumbel KL, gumbel τ, code usage entropy,
+    revived-codes count.
+  - `infer_collector_latents` for hold-across-steps (per-env countdown,
+    renew on done OR expiry).
+
+- `rlopt/agent/ipmd/ipmd.py`
+  - `IPMDLatentLearningConfig` extended (see §6 for config reference).
+  - `_inject_latent_command` posterior path uses
+    `learner.infer_collector_latents(td)` when present.
+
+### 4.2 IsaacLab-Imitation (worktree `IsaacLab-Imitation-vqvae`, branch `vqvae-impl`)
+
+- `tasks/manager_based/imitation/config/g1/imitation_g1_latent_vqvae_env_cfg.py`
+  — `ImitationG1LatentVQVAEEnvCfg` extends the latent G1 env with
+  `latent_patch_past_steps = 8`, `latent_patch_future_steps = 0`.
+  All other observation groups unchanged; `expert_window/*` already exists in
+  `G1ObservationCfg.ExpertWindowCfg` and is auto-synced via
+  `_sync_expert_window_observation_params`.
+
+- `tasks/manager_based/imitation/config/g1/agents/rlopt_ipmd_vqvae_cfg.py`
+  — `G1ImitationLatentRLOptIPMDVQVAEConfig`. Defaults:
+  - `method = "patch_vqvae"`, `quantizer = "fsq"`, `fsq_levels = [8,8,8,5,5]`.
+  - Posterior input keys = `expert_window/expert_motion`,
+    `expert_window/expert_anchor_pos_b`, `expert_window/expert_anchor_ori_b`.
+  - `recon_coeff = 1.0`, `action_recon_coeff = 0.5`,
+    `code_period = 30`, `latent_steps_min = latent_steps_max = 30`,
+    `command_source = "posterior"`, `latent_dim = 64`,
+    `train_posterior_through_policy = False`.
+  - Probe enabled.
+
+- `tasks/manager_based/imitation/config/g1/__init__.py`
+  — registers task ID **`Isaac-Imitation-G1-Latent-VQVAE-v0`** with
+  `rlopt_ipmd_vqvae_cfg_entry_point` (and aliases `rlopt_cfg_entry_point` /
+  `rlopt_ipmd_cfg_entry_point` to the same config so `--algo IPMD` works).
+
+## 5. Usage
+
+Smoke-test (uses `train.py`, since direct `import rlopt` pulls IsaacLab/IsaacSim
+through torchrl's gym wrapper):
+
+```bash
+cd /home/fwu91/Documents/Research/SkillLearning/IsaacLab-Imitation-vqvae
+
+conda run -n SkillLearning-vqvae python scripts/rlopt/train.py \
+    --task Isaac-Imitation-G1-Latent-VQVAE-v0 \
+    --algo IPMD \
+    --max_iterations 1 --num_envs 32 --headless \
+    env.lafan1_manifest_path=./data/unitree/manifests/g1_unitree_dance102_manifest.json
+```
+
+Switch quantizer via Hydra override:
+
+```bash
+... ipmd.latent_learning.quantizer=gumbel \
+    ipmd.latent_learning.gumbel_kl_to_uniform_coeff=0.01 \
+    ipmd.latent_learning.code_usage_entropy_coeff=0.01
+
+... ipmd.latent_learning.quantizer=vq_ema \
+    ipmd.latent_learning.codebook_size=512 \
+    ipmd.latent_learning.commitment_coeff=0.25 \
+    ipmd.latent_learning.dead_code_reset_iters=1000
+```
+
+Lint:
+
+```bash
+conda run -n SkillLearning-vqvae ruff check RLOpt-vqvae IsaacLab-Imitation-vqvae
+conda run -n SkillLearning-vqvae ruff format --check RLOpt-vqvae IsaacLab-Imitation-vqvae
+```
+
+## 6. Config reference (`ipmd.latent_learning.*`)
+
+### Common
+| Field | Default | Notes |
+|---|---|---|
+| `method` | `"patch_autoencoder"` | Set to `"patch_vqvae"` to use VQVAE. |
+| `posterior_input_keys` | `[]` | Should point to `expert_window/*` keys for windowed encoding. |
+| `patch_past_steps` / `patch_future_steps` | `0` / `0` | Algorithm-side hint; env supplies the actual window via `latent_patch_past_steps`. Keep them aligned. |
+| `encoder_hidden_dims` | `[256, 256]` | MLP encoder hidden widths. |
+| `decoder_hidden_dims` | `[256, 256]` | MLP decoder hidden widths. |
+| `lr` | `3e-4` | Latent-learner optimizer lr. |
+| `grad_clip_norm` | `1.0` | Latent-learner grad clip. |
+| `recon_coeff` | `0.0` | Window reconstruction MSE weight. Set > 0 for VQ-VAE. |
+| `weight_decay_coeff` | `0.0` | Optional L2 on encoder/decoder. |
+
+### VQ-VAE specific
+| Field | Default | Notes |
+|---|---|---|
+| `quantizer` | `"fsq"` | One of `"fsq" \| "vq_ema" \| "gumbel"`. |
+| `fsq_levels` | `[8,8,8,5,5]` | Effective codebook size = ∏ levels (default = 12 800). |
+| `codebook_size` | `512` | Used by `vq_ema` and `gumbel`. |
+| `codebook_embed_dim` | `None` | None → use `latent_dim`. |
+| `commitment_coeff` | `0.25` | β in van den Oord. `vq_ema` only. |
+| `ema_decay` | `0.99` | EMA codebook update decay. `vq_ema` only. |
+| `dead_code_reset_iters` | `0` | 0 disables. `vq_ema` only. |
+| `gumbel_tau_start` / `gumbel_tau_end` | `1.0` / `0.3` | Linear anneal. |
+| `gumbel_tau_anneal_iters` | `200_000` | Update calls until τ=end. |
+| `gumbel_hard` | `True` | ST hard forward, soft backward. |
+| `gumbel_kl_to_uniform_coeff` | `0.0` | KL(q‖U) regularizer. |
+| `code_usage_entropy_coeff` | `0.0` | Marginal usage entropy bonus. |
+| `action_recon_coeff` | `0.0` | If > 0, decode `expert_action` from `z_q`. |
+| `code_period` | `30` | Env steps per held code. |
+| `latent_dropout_to_random_code_prob` | `0.0` | Random-code substitution during PPO updates. **Not yet wired** (see §8). |
+
+## 7. Diagnostics logged
+
+Per `iterate()` call:
+
+- `train/ipmd/vqvae_total_loss`
+- `train/ipmd/vqvae_recon_mse`
+- `train/ipmd/vqvae_action_recon_mse`
+- `train/ipmd/vqvae_commit_loss` (vq_ema)
+- `train/ipmd/vqvae_gumbel_kl_uniform`, `vqvae_gumbel_tau` (gumbel)
+- `train/ipmd/vqvae_code_usage_entropy`
+- `train/ipmd/vqvae_codebook_perplexity` — **primary collapse indicator**
+- `train/ipmd/vqvae_dead_codes`, `vqvae_codes_revived`
+- `train/ipmd/vqvae_codebook_size`
+- `train/ipmd/vqvae_weight_decay`
+
+Plus the existing IPMD reward and PPO metrics. The optional `FeatureProbe`
+(reused from `policy_kl_bottleneck`) measures how much of the reward-input
+state the latent linearly preserves.
+
+## 8. Known caveats / not-yet-wired
+
+1. **`latent_dropout_to_random_code_prob` is parsed but not applied** — the
+   PPO update path does not currently swap inferred `z_q` with a random
+   codebook embedding. Easy follow-up: add a hook in
+   `_backward_ppo_terms` / posterior recompute that, with prob `p`, replaces
+   the latent with a uniformly-sampled codebook entry. Especially important
+   for `vq_ema`/`gumbel`; trivial for FSQ (sample random grid point).
+2. **No sequence encoder yet** — the encoder is a flatten + MLP over the
+   window. Ablation: causal 1-D TCN or small GRU/Transformer over `(B, T, F)`.
+   Add `encoder_type` in cfg.
+3. **No HL planner module** — out of scope for this PR. Recommended next
+   piece: tokenize expert trajectories (offline) + autoregressive transformer
+   over codes + BC pretrain. Place under `rlopt/agent/imitation/hl_planner/`.
+4. **Random-code training during BC** — `bc_coef > 0` will pull policy toward
+   expert action under expert-encoded code only. Add code-dropout to BC for
+   robustness.
+5. **No FSQ output regularization** — encoder pre-quantization can drift far
+   from the bounded grid. If saturation seen in `vqvae_recon_mse`, add a
+   small weight on `||z_e||²` or a tanh inside the encoder head.
+6. **`latent_steps_min == latent_steps_max == code_period`** in the new agent
+   cfg — keeps the `LatentCommandController` resample cadence in lockstep
+   with the learner's hold logic. If you change `code_period`, change the
+   range too.
+7. **Compatibility** — `patch_autoencoder` (current default) untouched.
+   Existing tasks unaffected. New task ID is purely additive.
+
+## 9. Future work (priority order)
+
+1. **Wire random-code dropout during PPO updates** (§8.1). 30-line change,
+   high payoff for downstream HL.
+2. **Tokenize expert trajectories offline** — script
+   `scripts/rlopt/tokenize_expert.py` reads expert dataset, runs the trained
+   encoder + quantizer, dumps per-chunk `code_id` to disk. Feeds HL planner.
+3. **HL planner v0**: autoregressive transformer over code tokens, BC + PPO
+   on top. Frozen LL.
+4. **Sequence encoder** (causal TCN / small GRU). Should help when
+   `code_period` grows past ~60.
+5. **RVQ fallback** if FSQ + EMA-VQ both hit recon ceiling. Drop-in
+   alternative quantizer.
+6. **Joint LL+HL fine-tune** via option-critic / HIRO. Risky; only after
+   v0 HL is solid.
+
+## 10. References
+
+- van den Oord, Vinyals, Kavukcuoglu. *Neural Discrete Representation
+  Learning* (VQ-VAE), NeurIPS 2017.
+- Razavi et al. *Generating Diverse High-Fidelity Images with VQ-VAE-2*,
+  NeurIPS 2019.
+- Mentzer et al. *Finite Scalar Quantization: VQ-VAE Made Simple*, ICLR 2024.
+- Jang, Gu, Poole. *Categorical Reparameterization with Gumbel-Softmax*,
+  ICLR 2017.
+- Maddison, Mnih, Teh. *The Concrete Distribution: A Continuous
+  Relaxation of Discrete Random Variables*, ICLR 2017.
+- Zeghidour et al. *SoundStream: An End-to-End Neural Audio Codec* (RVQ),
+  TASLP 2022.
+- Peng et al. *ASE: Adversarial Skill Embeddings for Physically Simulated
+  Characters*, SIGGRAPH 2022 — closest skill-codebook precedent for our
+  domain (continuous latents though).
+- Quest / TAP / PRISE / H-GAP — recent BC + token-VQ skill papers worth
+  comparing HL planner choices against.

--- a/rlopt/agent/fast_td3/fast_td3.py
+++ b/rlopt/agent/fast_td3/fast_td3.py
@@ -856,8 +856,10 @@ class FastTD3(BaseAlgorithm[FastTD3RLOptConfig]):
 
             # Save model periodically
             if (
-                self.config.save_interval > 0
-                and collected_frames % (self.config.save_interval * num_envs) == 0
+                self._should_save_checkpoint(
+                    frames_processed=collected_frames,
+                    frames_in_iteration=frames_in_batch,
+                )
             ):
                 self.save_model(
                     path=self.log_dir / self.config.logger.save_path,

--- a/rlopt/agent/gail/gail.py
+++ b/rlopt/agent/gail/gail.py
@@ -1177,9 +1177,10 @@ class GAIL(PPO[GailCfgT], Generic[GailCfgT]):
             self.collector.update_policy_weights_()
 
             if (
-                self.config.save_interval > 0
-                and int(collected_frames) > 0
-                and int(collected_frames) % self.config.save_interval == 0
+                self._should_save_checkpoint(
+                    frames_processed=int(collected_frames),
+                    frames_in_iteration=int(frames_in_batch),
+                )
             ):
                 self.save_model(
                     path=self.log_dir / self.config.logger.save_path,

--- a/rlopt/agent/imitation/latent_learning.py
+++ b/rlopt/agent/imitation/latent_learning.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torch.nn.functional as F
@@ -144,6 +145,40 @@ class BaseLatentLearner:
 
     def initialize(self, agent: IPMD) -> None:
         self.agent = agent
+
+    def checkpoint_state_dict(self) -> dict[str, Any]:
+        modules = {
+            name: module.state_dict()
+            for name, module in vars(self).items()
+            if isinstance(module, nn.Module)
+        }
+        optimizers = {
+            name: optimizer.state_dict()
+            for name, optimizer in vars(self).items()
+            if isinstance(optimizer, torch.optim.Optimizer)
+        }
+        return {
+            "modules": modules,
+            "optimizers": optimizers,
+            "extra": self._checkpoint_extra_state_dict(),
+        }
+
+    def load_checkpoint_state_dict(self, state: dict[str, Any]) -> None:
+        for name, module_state in state["modules"].items():
+            module = getattr(self, name)
+            module.load_state_dict(module_state)
+        for name, optimizer_state in state["optimizers"].items():
+            optimizer = getattr(self, name)
+            optimizer.load_state_dict(optimizer_state)
+        self._load_checkpoint_extra_state_dict(state["extra"])
+
+    def _checkpoint_extra_state_dict(self) -> dict[str, Any]:
+        return {}
+
+    def _load_checkpoint_extra_state_dict(self, state: dict[str, Any]) -> None:
+        if state:
+            msg = f"{type(self).__name__} does not load extra checkpoint state."
+            raise NotImplementedError(msg)
 
     def required_patch_obs_keys(self) -> list[BatchKey]:
         return []
@@ -914,6 +949,17 @@ class FixedProjectionLatentLearner(BaseLatentLearner):
         super().__init__()
         self._projection: Tensor | None = None
 
+    def _checkpoint_extra_state_dict(self) -> dict[str, Any]:
+        if self._projection is None:
+            return {}
+        return {"projection": self._projection}
+
+    def _load_checkpoint_extra_state_dict(self, state: dict[str, Any]) -> None:
+        if not state:
+            return
+        assert self.agent is not None
+        self._projection = cast(Tensor, state["projection"]).to(self.agent.device)
+
     def _posterior_input_keys(self) -> list[BatchKey]:
         assert self.agent is not None
         cfg = self.agent.config.ipmd.latent_learning
@@ -1035,12 +1081,780 @@ class FixedProjectionLatentLearner(BaseLatentLearner):
         return latents.to(device=device, dtype=dtype)
 
 
+class FSQQuantizer(nn.Module):
+    """Finite Scalar Quantization (Mentzer 2023).
+
+    Per-dim bounded scalar quantization. No codebook params, no aux loss, no
+    collapse risk. Effective codebook size = ``prod(levels)``.
+    """
+
+    def __init__(self, levels: list[int]) -> None:
+        super().__init__()
+        if len(levels) == 0:
+            msg = "FSQQuantizer requires at least one level."
+            raise ValueError(msg)
+        if any(int(level) < 2 for level in levels):
+            msg = f"FSQ levels must each be >= 2, got {levels!r}."
+            raise ValueError(msg)
+        levels_i = torch.tensor([int(level) for level in levels], dtype=torch.long)
+        levels_t = levels_i.to(torch.float32)
+        # Half range per dim: integer indices range over [-half, half] (with one extra
+        # for even L).  We follow the canonical implementation.
+        self.register_buffer("levels", levels_t)
+        self.register_buffer("_levels_i", levels_i)
+        self.register_buffer(
+            "_basis",
+            torch.cumprod(
+                torch.cat([torch.ones(1), levels_t[:-1]]),
+                dim=0,
+            ).to(torch.long),
+        )
+        self.code_dim = len(levels)
+
+    @property
+    def codebook_size(self) -> int:
+        return int(self.levels.prod().item())
+
+    def _bound(self, z: Tensor) -> Tensor:
+        # Squash to [-1, 1] with extra slack so the rounded grid stays inside.
+        half_l = (self.levels - 1) * 0.5
+        offset = torch.where(
+            self.levels % 2 == 0,
+            torch.tensor(0.5, device=z.device),
+            torch.tensor(0.0, device=z.device),
+        )
+        shift = torch.atanh(offset / half_l.clamp(min=1.0))
+        return (z + shift).tanh() * half_l - offset
+
+    def forward(self, z_e: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        bounded = self._bound(z_e)
+        rounded = torch.round(bounded)
+        # Straight-through estimator.
+        z_q = bounded + (rounded - bounded).detach()
+        # Code id: shift to non-negative integer indices then mix with basis.
+        levels_i = self._levels_i.to(rounded.device)
+        zhat = rounded.to(torch.long) + levels_i // 2
+        zhat = zhat.clamp(min=0)
+        zhat = torch.minimum(zhat, levels_i - 1)
+        code = (zhat * self._basis.to(zhat.device)).sum(dim=-1)
+        return z_q, code, bounded
+
+
+class EMAVQQuantizer(nn.Module):
+    """Standard VQ-VAE quantizer with EMA codebook updates + commitment loss."""
+
+    def __init__(
+        self,
+        codebook_size: int,
+        embed_dim: int,
+        *,
+        decay: float = 0.99,
+        eps: float = 1e-5,
+        commitment_coeff: float = 0.25,
+    ) -> None:
+        super().__init__()
+        self.codebook_size = int(codebook_size)
+        self.embed_dim = int(embed_dim)
+        self.decay = float(decay)
+        self.eps = float(eps)
+        self.commitment_coeff = float(commitment_coeff)
+
+        embedding = torch.randn(self.codebook_size, self.embed_dim) * 0.01
+        self.register_buffer("embedding", embedding)
+        self.register_buffer("cluster_size", torch.zeros(self.codebook_size))
+        self.register_buffer("cluster_sum", embedding.clone())
+        self.register_buffer("_initialized", torch.tensor(False))
+
+    @torch.no_grad()
+    def _kmeans_init(self, z_e: Tensor) -> None:
+        flat = z_e.reshape(-1, self.embed_dim)
+        if flat.shape[0] == 0:
+            return
+        if flat.shape[0] >= self.codebook_size:
+            idx = torch.randperm(flat.shape[0], device=flat.device)[
+                : self.codebook_size
+            ]
+        else:
+            idx = torch.randint(
+                0, flat.shape[0], (self.codebook_size,), device=flat.device
+            )
+        self.embedding.copy_(flat[idx])
+        self.cluster_sum.copy_(self.embedding)
+        self.cluster_size.fill_(1.0)
+        self._initialized.fill_(True)
+
+    def _quantize(self, z_e: Tensor) -> tuple[Tensor, Tensor]:
+        flat = z_e.reshape(-1, self.embed_dim)
+        # Squared distance to each code.
+        dist = (
+            flat.pow(2).sum(-1, keepdim=True)
+            - 2.0 * flat @ self.embedding.t()
+            + self.embedding.pow(2).sum(-1)
+        )
+        code = dist.argmin(dim=-1)
+        z_q = F.embedding(code, self.embedding)
+        z_q = z_q.reshape_as(z_e)
+        code = code.reshape(z_e.shape[:-1])
+        return z_q, code
+
+    def forward(self, z_e: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        if self.training and not bool(self._initialized.item()):
+            self._kmeans_init(z_e.detach())
+        z_q, code = self._quantize(z_e)
+        commitment = F.mse_loss(z_e, z_q.detach())
+        # Straight-through.
+        z_q_st = z_e + (z_q - z_e).detach()
+
+        if self.training:
+            with torch.no_grad():
+                flat = z_e.detach().reshape(-1, self.embed_dim)
+                code_flat = code.reshape(-1)
+                onehot = F.one_hot(code_flat, self.codebook_size).to(flat.dtype)
+                cluster_size_new = onehot.sum(dim=0)
+                cluster_sum_new = onehot.t() @ flat
+                self.cluster_size.mul_(self.decay).add_(
+                    cluster_size_new, alpha=1.0 - self.decay
+                )
+                self.cluster_sum.mul_(self.decay).add_(
+                    cluster_sum_new, alpha=1.0 - self.decay
+                )
+                n = self.cluster_size.sum()
+                cluster_size_smoothed = (
+                    (self.cluster_size + self.eps)
+                    / (n + self.codebook_size * self.eps)
+                    * n
+                )
+                self.embedding.copy_(
+                    self.cluster_sum / cluster_size_smoothed.unsqueeze(-1)
+                )
+
+        return z_q_st, code, commitment * self.commitment_coeff
+
+    @torch.no_grad()
+    def revive_dead_codes(self, z_e: Tensor, *, threshold: float = 1e-3) -> int:
+        """Reinit unused codes from the current encoder distribution."""
+        flat = z_e.detach().reshape(-1, self.embed_dim)
+        if flat.shape[0] == 0:
+            return 0
+        dead = self.cluster_size < threshold
+        n_dead = int(dead.sum().item())
+        if n_dead == 0:
+            return 0
+        idx = torch.randint(0, flat.shape[0], (n_dead,), device=flat.device)
+        self.embedding[dead] = flat[idx]
+        self.cluster_sum[dead] = self.embedding[dead]
+        self.cluster_size[dead] = 1.0
+        return n_dead
+
+
+class GumbelQuantizer(nn.Module):
+    """Categorical bottleneck via Gumbel-Softmax with optional straight-through."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        codebook_size: int,
+        embed_dim: int,
+    ) -> None:
+        super().__init__()
+        self.codebook_size = int(codebook_size)
+        self.embed_dim = int(embed_dim)
+        self.logit_head = nn.Linear(input_dim, self.codebook_size)
+        self.codebook = nn.Embedding(self.codebook_size, self.embed_dim)
+        nn.init.normal_(self.codebook.weight, mean=0.0, std=0.02)
+
+    def forward(
+        self,
+        z_e: Tensor,
+        *,
+        tau: float,
+        hard: bool,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        logits = self.logit_head(z_e)
+        if self.training:
+            y = F.gumbel_softmax(logits, tau=max(float(tau), 1e-3), hard=hard, dim=-1)
+        else:
+            idx = logits.argmax(dim=-1)
+            y = F.one_hot(idx, self.codebook_size).to(logits.dtype)
+        z_q = y @ self.codebook.weight
+        code = logits.argmax(dim=-1)
+        log_q = F.log_softmax(logits, dim=-1)
+        # KL(q || Uniform) = sum q*(log q - log(1/K)) = sum q*log q + log K
+        kl_uniform = (log_q.exp() * log_q).sum(-1).mean() + math.log(self.codebook_size)
+        return z_q, code, kl_uniform, log_q
+
+
+class PatchVQVAELatentLearner(BaseLatentLearner):
+    """Vector-quantized autoencoder over expert windows.
+
+    - Encoder: MLP over flattened posterior-input features (typically a window
+      of expert states; configure ``patch_past_steps`` / ``patch_future_steps``
+      and point ``posterior_input_keys`` at the windowed observation terms).
+    - Quantizer: ``"fsq" | "vq_ema" | "gumbel" | "identity"`` selectable via cfg.
+    - Decoder: MLP reconstructing the flattened window features. Optional
+      action decoder reconstructs ``expert_action`` from the quantized latent
+      to ground codes in behavior, not just kinematics.
+
+    During posterior-command rollout, each env encodes a fresh expert window at
+    code boundaries and holds that code for ``code_period`` env steps.
+    """
+
+    uses_aux_reward = False
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.encoder: DeterministicLatentModel | None = None
+        self.decoder: LatentDecoder | None = None
+        self.action_decoder: LatentDecoder | None = None
+        self.code_to_latent: nn.Linear | None = None
+        self.fsq: FSQQuantizer | None = None
+        self.vq: EMAVQQuantizer | None = None
+        self.gumbel: GumbelQuantizer | None = None
+        self.optimizer: torch.optim.Optimizer | None = None
+
+        self._update_calls: int = 0
+        self._collector_z_q: Tensor | None = None
+        self._collector_steps: Tensor | None = None
+
+    def _checkpoint_extra_state_dict(self) -> dict[str, Any]:
+        return {"update_calls": self._update_calls}
+
+    def _load_checkpoint_extra_state_dict(self, state: dict[str, Any]) -> None:
+        self._update_calls = int(state["update_calls"])
+
+    # ----- config / key helpers --------------------------------------------------
+    def _config(self):
+        assert self.agent is not None
+        return self.agent.config.ipmd.latent_learning
+
+    def _quantizer_kind(self) -> str:
+        return str(self._config().quantizer).strip().lower()
+
+    def _phase_dim(self) -> int:
+        cfg = self._config()
+        return 2 if str(cfg.command_phase_mode).strip().lower() == "sin_cos" else 0
+
+    def _code_latent_dim(self) -> int:
+        assert self.agent is not None
+        cfg = self._config()
+        if cfg.code_latent_dim is not None and int(cfg.code_latent_dim) > 0:
+            return int(cfg.code_latent_dim)
+        return int(self.agent._latent_dim) - self._phase_dim()
+
+    def _embed_dim(self) -> int:
+        cfg = self._config()
+        if cfg.codebook_embed_dim is not None and int(cfg.codebook_embed_dim) > 0:
+            return int(cfg.codebook_embed_dim)
+        return self._code_latent_dim()
+
+    def _posterior_input_keys(self) -> list[BatchKey]:
+        assert self.agent is not None
+        cfg = self._config()
+        if cfg.posterior_input_keys:
+            return dedupe_keys(list(cfg.posterior_input_keys))
+        return list(self.agent._posterior_obs_keys)
+
+    def required_expert_batch_keys(self) -> list[BatchKey]:
+        keys = self._posterior_input_keys()
+        if float(self._config().action_recon_coeff) > 0.0:
+            keys = [*list(keys), cast(BatchKey, "expert_action")]
+        return dedupe_keys(keys)
+
+    # ----- features / module construction ---------------------------------------
+    def _features_from_td(
+        self,
+        td: TensorDict,
+        *,
+        detach: bool,
+    ) -> Tensor:
+        assert self.agent is not None
+        parts: list[Tensor] = []
+        for key in self._posterior_input_keys():
+            value = cast(Tensor, td.get(key)).to(self.agent.device)
+            value = value.detach() if detach else value
+            parts.append(value.reshape(value.shape[0], -1))
+        return parts[0] if len(parts) == 1 else torch.cat(parts, dim=-1)
+
+    def _ensure_modules(self, input_dim: int) -> None:
+        assert self.agent is not None
+        cfg = self._config()
+        kind = self._quantizer_kind()
+        embed_dim = self._embed_dim()
+        code_latent_dim = self._code_latent_dim()
+
+        if kind == "fsq":
+            if self.fsq is None:
+                self.fsq = FSQQuantizer(list(cfg.fsq_levels)).to(self.agent.device)
+            encoder_out_dim = self.fsq.code_dim
+        elif kind == "vq_ema":
+            encoder_out_dim = embed_dim
+            if self.vq is None:
+                self.vq = EMAVQQuantizer(
+                    codebook_size=int(cfg.codebook_size),
+                    embed_dim=embed_dim,
+                    decay=float(cfg.ema_decay),
+                    commitment_coeff=float(cfg.commitment_coeff),
+                ).to(self.agent.device)
+        elif kind == "gumbel":
+            encoder_out_dim = max(
+                int(cfg.encoder_hidden_dims[-1]) if cfg.encoder_hidden_dims else 256, 1
+            )
+            if self.gumbel is None:
+                self.gumbel = GumbelQuantizer(
+                    input_dim=encoder_out_dim,
+                    codebook_size=int(cfg.codebook_size),
+                    embed_dim=embed_dim,
+                ).to(self.agent.device)
+        elif kind == "identity":
+            encoder_out_dim = code_latent_dim
+        else:
+            msg = (
+                f"Unknown quantizer={kind!r} for patch_vqvae. "
+                "Expected 'fsq', 'vq_ema', 'gumbel', or 'identity'."
+            )
+            raise ValueError(msg)
+
+        if self.encoder is None:
+            self.encoder = DeterministicLatentModel(
+                input_dim=input_dim,
+                latent_dim=encoder_out_dim,
+                hidden_dims=list(cfg.encoder_hidden_dims),
+                activation=cfg.encoder_activation,
+            ).to(self.agent.device)
+
+        if kind in {"vq_ema", "gumbel"}:
+            quantized_dim = embed_dim
+        elif kind == "identity":
+            quantized_dim = code_latent_dim
+        else:
+            assert self.fsq is not None
+            quantized_dim = self.fsq.code_dim
+        if self.code_to_latent is None and quantized_dim != code_latent_dim:
+            self.code_to_latent = nn.Linear(quantized_dim, code_latent_dim).to(
+                self.agent.device
+            )
+
+        decoder_in_dim = quantized_dim
+        if self.decoder is None:
+            self.decoder = LatentDecoder(
+                latent_dim=decoder_in_dim,
+                output_dim=input_dim,
+                hidden_dims=list(cfg.decoder_hidden_dims),
+                activation=cfg.decoder_activation,
+            ).to(self.agent.device)
+
+        if float(cfg.action_recon_coeff) > 0.0 and self.action_decoder is None:
+            action_dim = int(self.agent._action_feature_dim)
+            self.action_decoder = LatentDecoder(
+                latent_dim=decoder_in_dim,
+                output_dim=action_dim,
+                hidden_dims=list(cfg.decoder_hidden_dims),
+                activation=cfg.decoder_activation,
+            ).to(self.agent.device)
+
+        if self.optimizer is None:
+            params: list[nn.Parameter] = []
+            params += list(self.encoder.parameters())
+            params += list(self.decoder.parameters())
+            if self.action_decoder is not None:
+                params += list(self.action_decoder.parameters())
+            if self.code_to_latent is not None:
+                params += list(self.code_to_latent.parameters())
+            if self.gumbel is not None:
+                params += list(self.gumbel.parameters())
+            # vq_ema codebook updates are EMA-only, no optimizer entry required.
+            self.optimizer = torch.optim.Adam(params, lr=float(cfg.lr))
+
+    def initialize(self, agent: IPMD) -> None:
+        super().initialize(agent)
+        input_dim = sum(
+            agent._obs_feature_dims[key] for key in self._posterior_input_keys()
+        )
+        self._ensure_modules(int(input_dim))
+
+    # ----- core encode + quantize -----------------------------------------------
+    def _current_tau(self) -> float:
+        cfg = self._config()
+        if int(cfg.gumbel_tau_anneal_iters) <= 0:
+            return float(cfg.gumbel_tau_end)
+        progress = min(
+            1.0,
+            float(self._update_calls) / float(cfg.gumbel_tau_anneal_iters),
+        )
+        return float(cfg.gumbel_tau_start) + progress * (
+            float(cfg.gumbel_tau_end) - float(cfg.gumbel_tau_start)
+        )
+
+    def _quantize(
+        self,
+        z_e: Tensor,
+    ) -> dict[str, Tensor]:
+        kind = self._quantizer_kind()
+        out: dict[str, Tensor] = {}
+        if kind == "fsq":
+            assert self.fsq is not None
+            z_q, code, _ = self.fsq(z_e)
+            out["z_q"] = z_q
+            out["code"] = code
+            out["aux_loss"] = torch.zeros((), device=z_e.device)
+        elif kind == "vq_ema":
+            assert self.vq is not None
+            z_q, code, commitment = self.vq(z_e)
+            out["z_q"] = z_q
+            out["code"] = code
+            out["aux_loss"] = commitment
+        elif kind == "gumbel":
+            assert self.gumbel is not None
+            tau = self._current_tau()
+            z_q, code, kl_uniform, log_q = self.gumbel(
+                z_e, tau=tau, hard=bool(self._config().gumbel_hard)
+            )
+            out["z_q"] = z_q
+            out["code"] = code
+            out["aux_loss"] = kl_uniform
+            out["log_q"] = log_q
+            out["tau"] = torch.tensor(tau, device=z_e.device)
+        elif kind == "identity":
+            out["z_q"] = z_e
+            out["code"] = torch.zeros(
+                z_e.shape[:-1],
+                device=z_e.device,
+                dtype=torch.long,
+            )
+            out["aux_loss"] = torch.zeros((), device=z_e.device)
+        return out
+
+    def _project_to_code_latent(self, z_q: Tensor) -> Tensor:
+        if self.code_to_latent is None:
+            return z_q
+        return self.code_to_latent(z_q)
+
+    def _append_command_phase(
+        self,
+        code_latents: Tensor,
+        phase: Tensor,
+    ) -> Tensor:
+        if self._phase_dim() == 0:
+            return code_latents
+        angle = phase.to(device=code_latents.device, dtype=code_latents.dtype)
+        angle = angle.reshape(-1) * (2.0 * math.pi)
+        phase_features = torch.stack((torch.sin(angle), torch.cos(angle)), dim=-1)
+        return torch.cat((code_latents, phase_features), dim=-1)
+
+    def _infer_code_latents(
+        self,
+        batch: TensorDict,
+        *,
+        detach: bool,
+    ) -> Tensor:
+        features = self._features_from_td(batch, detach=detach)
+        self._ensure_modules(int(features.shape[-1]))
+        assert self.encoder is not None
+        if detach:
+            with torch.no_grad():
+                z_e = self.encoder(features)
+                quant = self._quantize(z_e)
+                return self._project_to_code_latent(quant["z_q"])
+        z_e = self.encoder(features)
+        quant = self._quantize(z_e)
+        return self._project_to_code_latent(quant["z_q"])
+
+    # ----- BaseLatentLearner interface ------------------------------------------
+    def infer_batch_latents(
+        self,
+        batch: TensorDict,
+        *,
+        detach: bool,
+        context: str,
+    ) -> Tensor | None:
+        del context
+        code_latents = self._infer_code_latents(batch, detach=detach)
+        phase = torch.zeros(
+            code_latents.shape[0],
+            device=code_latents.device,
+            dtype=code_latents.dtype,
+        )
+        return self._append_command_phase(code_latents, phase)
+
+    def infer_expert_latents(
+        self,
+        expert_batch: TensorDict,
+        *,
+        detach: bool,
+    ) -> Tensor:
+        latent = self.infer_batch_latents(
+            expert_batch,
+            detach=detach,
+            context="expert latent batch",
+        )
+        if latent is None:
+            msg = "patch_vqvae failed to infer expert latents."
+            raise RuntimeError(msg)
+        return latent
+
+    def reconstruct_batch_features(
+        self,
+        batch: TensorDict,
+        *,
+        detach: bool,
+        context: str,
+    ) -> Tensor | None:
+        del context
+        features = self._features_from_td(batch, detach=detach)
+        self._ensure_modules(int(features.shape[-1]))
+        assert self.encoder is not None
+        assert self.decoder is not None
+        if detach:
+            with torch.no_grad():
+                z_e = self.encoder(features)
+                quant = self._quantize(z_e)
+                return self.decoder(quant["z_q"])
+        z_e = self.encoder(features)
+        quant = self._quantize(z_e)
+        return self.decoder(quant["z_q"])
+
+    def sample_expert_prior_latents(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> Tensor | None:
+        assert self.agent is not None
+        expert_batch = self.agent._next_expert_batch(
+            batch_size,
+            required_keys=self.required_expert_batch_keys(),
+        )
+        latents = self.infer_expert_latents(expert_batch, detach=True)
+        return latents.to(device=device, dtype=dtype)
+
+    # ----- collector hold-across-steps ------------------------------------------
+    def _renew_collector_codes(
+        self,
+        td: TensorDict,
+        renew_mask: Tensor,
+    ) -> None:
+        assert self.agent is not None
+        latents = self._infer_code_latents(
+            td,
+            detach=True,
+        )
+        latents = latents.to(self.agent.device).reshape(-1, self._code_latent_dim())
+        if self._collector_z_q is None or self._collector_z_q.shape != latents.shape:
+            self._collector_z_q = latents.clone()
+        else:
+            self._collector_z_q[renew_mask] = latents[renew_mask]
+
+    def infer_collector_latents(self, td: TensorDict) -> Tensor:
+        """Publish one held code per env, plus optional within-code phase."""
+        assert self.agent is not None
+        cfg = self._config()
+        device = self.agent.device
+        command_dim = int(self.agent._latent_dim)
+        code_latent_dim = self._code_latent_dim()
+        batch_size = int(td.numel())
+        if batch_size <= 0:
+            return torch.empty(0, command_dim, device=device)
+
+        if (
+            self._collector_z_q is None
+            or self._collector_z_q.shape[0] != batch_size
+            or self._collector_z_q.shape[1] != code_latent_dim
+            or self._collector_z_q.device != device
+        ):
+            self._collector_z_q = torch.zeros(
+                batch_size, code_latent_dim, device=device
+            )
+            self._collector_steps = torch.zeros(
+                batch_size, device=device, dtype=torch.long
+            )
+
+        assert self._collector_steps is not None
+        period = max(1, int(cfg.code_period))
+        done_mask = self._build_done_mask(td, batch_size=batch_size, device=device)
+        renew_mask = done_mask | (self._collector_steps <= 0)
+        if bool(renew_mask.any()):
+            self._renew_collector_codes(td, renew_mask)
+            self._collector_steps[renew_mask] = period
+        phase = (period - self._collector_steps).clamp(min=0).to(torch.float32)
+        phase = phase / float(period)
+        command = self._append_command_phase(self._collector_z_q, phase)
+        self._collector_steps -= 1
+        return command
+
+    @staticmethod
+    def _build_done_mask(
+        td: TensorDict, *, batch_size: int, device: torch.device
+    ) -> Tensor:
+        mask = torch.zeros(batch_size, device=device, dtype=torch.bool)
+        candidates: list[BatchKey] = [
+            cast(BatchKey, "done"),
+            cast(BatchKey, "terminated"),
+            cast(BatchKey, "truncated"),
+            cast(BatchKey, "is_init"),
+            cast(BatchKey, ("next", "done")),
+            cast(BatchKey, ("next", "terminated")),
+            cast(BatchKey, ("next", "truncated")),
+        ]
+        keys = td.keys(True)
+        for key in candidates:
+            if key not in keys:
+                continue
+            value = cast(Tensor, td.get(key)).reshape(-1).to(device=device).bool()
+            if value.numel() == batch_size:
+                mask |= value
+        return mask
+
+    # ----- training update -------------------------------------------------------
+    def update(self, rollout_flat: TensorDict) -> dict[str, float]:
+        del rollout_flat
+        assert self.agent is not None
+        cfg = self._config()
+        if float(cfg.recon_coeff) <= 0.0 and float(cfg.action_recon_coeff) <= 0.0:
+            return {}
+
+        expert_td = self.agent._next_expert_batch(
+            required_keys=self.required_expert_batch_keys()
+        )
+        features = self._features_from_td(expert_td, detach=False)
+        if features.shape[0] == 0:
+            return {}
+
+        self._ensure_modules(int(features.shape[-1]))
+        assert self.encoder is not None
+        assert self.decoder is not None
+        assert self.optimizer is not None
+
+        z_e = self.encoder(features)
+        quant = self._quantize(z_e)
+        z_q = quant["z_q"]
+        code = quant["code"]
+        aux_loss = quant["aux_loss"]
+
+        recon = self.decoder(z_q)
+        recon_loss = F.mse_loss(recon, features)
+
+        action_loss = torch.zeros((), device=self.agent.device)
+        if (
+            float(cfg.action_recon_coeff) > 0.0
+            and self.action_decoder is not None
+            and "expert_action" in expert_td.keys(True)
+        ):
+            expert_action = cast(Tensor, expert_td.get("expert_action")).to(
+                self.agent.device
+            )
+            expert_action_flat = expert_action.reshape(expert_action.shape[0], -1)
+            pred_action = self.action_decoder(z_q)
+            action_loss = F.mse_loss(pred_action, expert_action_flat)
+
+        weight_decay = torch.zeros((), device=self.agent.device)
+        if float(cfg.weight_decay_coeff) > 0.0:
+            for module in (self.encoder, self.decoder):
+                for param in module.parameters():
+                    if param.ndim >= 2:
+                        weight_decay = weight_decay + param.pow(2).mean()
+
+        gumbel_kl = torch.zeros((), device=self.agent.device)
+        usage_entropy = torch.zeros((), device=self.agent.device)
+        if self._quantizer_kind() == "gumbel":
+            gumbel_kl = aux_loss
+            if float(cfg.code_usage_entropy_coeff) > 0.0 and "log_q" in quant:
+                log_q = quant["log_q"]
+                marginal = log_q.exp().mean(dim=0).clamp(min=1e-8)
+                usage_entropy = -(marginal * marginal.log()).sum()
+        commit_loss = (
+            aux_loss
+            if self._quantizer_kind() == "vq_ema"
+            else torch.zeros((), device=self.agent.device)
+        )
+
+        total = (
+            float(cfg.recon_coeff) * recon_loss
+            + float(cfg.action_recon_coeff) * action_loss
+            + commit_loss
+            + float(cfg.gumbel_kl_to_uniform_coeff) * gumbel_kl
+            - float(cfg.code_usage_entropy_coeff) * usage_entropy
+            + float(cfg.weight_decay_coeff) * weight_decay
+        )
+
+        self.optimizer.zero_grad(set_to_none=True)
+        total.backward()
+        if float(cfg.grad_clip_norm) > 0.0:
+            params: list[nn.Parameter] = []
+            params += list(self.encoder.parameters())
+            params += list(self.decoder.parameters())
+            if self.action_decoder is not None:
+                params += list(self.action_decoder.parameters())
+            if self.code_to_latent is not None:
+                params += list(self.code_to_latent.parameters())
+            if self.gumbel is not None:
+                params += list(self.gumbel.parameters())
+            clip_grad_norm_(params, float(cfg.grad_clip_norm))
+        self.optimizer.step()
+
+        # Code-usage diagnostics + dead-code revival.
+        with torch.no_grad():
+            code_flat = code.reshape(-1)
+            codebook_size = self._codebook_size()
+            usage_hist = torch.bincount(code_flat, minlength=codebook_size).float()
+            usage_prob = usage_hist / usage_hist.sum().clamp(min=1.0)
+            perplexity = torch.exp(
+                -(usage_prob * (usage_prob.clamp(min=1e-12)).log()).sum()
+            )
+            dead_codes = int((usage_hist <= 0).sum().item())
+
+        revived = 0
+        if (
+            self._quantizer_kind() == "vq_ema"
+            and int(cfg.dead_code_reset_iters) > 0
+            and self._update_calls > 0
+            and self._update_calls % int(cfg.dead_code_reset_iters) == 0
+        ):
+            assert self.vq is not None
+            revived = self.vq.revive_dead_codes(z_e.detach())
+
+        self._update_calls += 1
+
+        metrics: dict[str, float] = {
+            "ipmd/vqvae_total_loss": float(total.detach().item()),
+            "ipmd/vqvae_recon_mse": float(recon_loss.detach().item()),
+            "ipmd/vqvae_action_recon_mse": float(action_loss.detach().item()),
+            "ipmd/vqvae_commit_loss": float(commit_loss.detach().item()),
+            "ipmd/vqvae_gumbel_kl_uniform": float(gumbel_kl.detach().item()),
+            "ipmd/vqvae_code_usage_entropy": float(usage_entropy.detach().item()),
+            "ipmd/vqvae_codebook_perplexity": float(perplexity.item()),
+            "ipmd/vqvae_dead_codes": float(dead_codes),
+            "ipmd/vqvae_codebook_size": float(self._codebook_size()),
+            "ipmd/vqvae_codes_revived": float(revived),
+            "ipmd/vqvae_weight_decay": float(weight_decay.detach().item()),
+        }
+        if self._quantizer_kind() == "gumbel":
+            metrics["ipmd/vqvae_gumbel_tau"] = float(self._current_tau())
+        return metrics
+
+    def _codebook_size(self) -> int:
+        kind = self._quantizer_kind()
+        if kind == "fsq":
+            assert self.fsq is not None
+            return self.fsq.codebook_size
+        if kind == "vq_ema":
+            assert self.vq is not None
+            return self.vq.codebook_size
+        if kind == "gumbel":
+            assert self.gumbel is not None
+            return self.gumbel.codebook_size
+        if kind == "identity":
+            return 1
+        return 0
+
+
 def _build_registry() -> dict[str, Callable[[], BaseLatentLearner]]:
     return {
         "patch_autoencoder": PatchAutoencoderLatentLearner,
         "policy_kl_bottleneck": PolicyKLBottleneckLatentLearner,
         "policy_mlp_embedding": PolicyMLPEmbeddingLatentLearner,
         "fixed_projection": FixedProjectionLatentLearner,
+        "patch_vqvae": PatchVQVAELatentLearner,
     }
 
 

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -4,7 +4,7 @@ import math
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -131,6 +131,129 @@ class IPMDLatentLearningConfig:
     probe_grad_clip_norm: float = 1.0
     probe_batch_size: int = 8192
     """Probe for analyzing the latent learner. """
+
+    log_std_min: float = -5.0
+    log_std_max: float = 2.0
+    """Clamps applied to learned log_std heads (Gaussian latent models)."""
+
+    uniformity_coeff: float = 0.0
+    """Weight on the latent uniformity penalty for ``policy_mlp_embedding``."""
+
+    # ----- VQ-VAE / discrete-skill latent settings (used by patch_vqvae) -----
+    quantizer: str = "fsq"
+    """Quantizer choice for ``patch_vqvae``.
+
+    One of ``"fsq" | "vq_ema" | "gumbel" | "identity"``. ``"identity"``
+    keeps the same temporal hold path but removes discrete quantization.
+    """
+
+    code_latent_dim: int | None = None
+    """Latent code width before optional command-phase features.
+
+    ``None`` uses ``ipmd.latent_dim`` when ``command_phase_mode="none"`` and
+    ``ipmd.latent_dim - 2`` when ``command_phase_mode="sin_cos"``.
+    """
+
+    command_phase_mode: str = "none"
+    """Optional phase features appended to held rollout commands.
+
+    Supported values:
+    - ``"none"``: publish only the held code latent.
+    - ``"sin_cos"``: append ``sin(phase), cos(phase)`` within the current hold.
+    """
+
+    fsq_levels: list[int] = field(default_factory=lambda: [8, 8, 8, 5, 5])
+    """Per-dimension level counts for FSQ. Effective codebook size = prod(levels)."""
+
+    codebook_size: int = 512
+    """Codebook size for ``vq_ema`` and ``gumbel`` quantizers."""
+
+    codebook_embed_dim: int | None = None
+    """Embedding dim for codebook entries. ``None`` defaults to ``IPMDConfig.latent_dim``."""
+
+    commitment_coeff: float = 0.25
+    """Commitment-loss weight for ``vq_ema`` (``beta`` in van den Oord 2017)."""
+
+    ema_decay: float = 0.99
+    """EMA decay for codebook updates in ``vq_ema``."""
+
+    dead_code_reset_iters: int = 0
+    """Cadence (in update calls) for reviving unused codes via reinit. 0 disables."""
+
+    gumbel_tau_start: float = 1.0
+    gumbel_tau_end: float = 0.3
+    gumbel_tau_anneal_iters: int = 200_000
+    """Gumbel-Softmax temperature anneal schedule (linear)."""
+
+    gumbel_hard: bool = True
+    """Straight-through hard Gumbel forward, soft backward."""
+
+    gumbel_kl_to_uniform_coeff: float = 0.0
+    """``KL(q(c|x) || Uniform(K))`` regularizer (gumbel only)."""
+
+    code_usage_entropy_coeff: float = 0.0
+    """Marginal-code-usage entropy bonus to discourage collapse (gumbel only)."""
+
+    action_recon_coeff: float = 0.0
+    """If > 0, an extra decoder reconstructs ``expert_action`` from the quantized latent."""
+
+    code_period: int = 30
+    """Env steps a sampled code is held during rollout collection.
+
+    Used by ``patch_vqvae`` when ``ipmd.command_source == "posterior"``.
+    The generic latent command controller's ``latent_steps_min/max`` settings
+    are bypassed in that posterior path.
+    """
+
+    latent_dropout_to_random_code_prob: float = 0.0
+    """Reserved for random-code substitution during PPO updates."""
+
+    def validate(self, *, command_dim: int) -> None:
+        self.quantizer = str(self.quantizer).strip().lower()
+        if self.quantizer not in {"fsq", "vq_ema", "gumbel", "identity"}:
+            msg = (
+                "ipmd.latent_learning.quantizer must be one of "
+                "'fsq', 'vq_ema', 'gumbel', or 'identity', got "
+                f"{self.quantizer!r}."
+            )
+            raise ValueError(msg)
+
+        self.command_phase_mode = str(self.command_phase_mode).strip().lower()
+        if self.command_phase_mode not in {"none", "sin_cos"}:
+            msg = (
+                "ipmd.latent_learning.command_phase_mode must be 'none' or "
+                f"'sin_cos', got {self.command_phase_mode!r}."
+            )
+            raise ValueError(msg)
+
+        self.code_period = require_positive_int(
+            "ipmd.latent_learning.code_period", self.code_period
+        )
+        if self.code_latent_dim is not None:
+            self.code_latent_dim = require_positive_int(
+                "ipmd.latent_learning.code_latent_dim", self.code_latent_dim
+            )
+
+        phase_dim = 2 if self.command_phase_mode == "sin_cos" else 0
+        code_dim = (
+            int(self.code_latent_dim)
+            if self.code_latent_dim is not None
+            else int(command_dim) - phase_dim
+        )
+        if code_dim <= 0:
+            msg = (
+                "ipmd.latent_learning.code_latent_dim must leave a positive code "
+                f"width after phase features, got command_dim={command_dim}, "
+                f"phase_dim={phase_dim}."
+            )
+            raise ValueError(msg)
+        if code_dim + phase_dim != int(command_dim):
+            msg = (
+                "ipmd.latent_dim must equal code_latent_dim plus phase feature "
+                f"width, got latent_dim={command_dim}, code_latent_dim={code_dim}, "
+                f"phase_dim={phase_dim}."
+            )
+            raise ValueError(msg)
 
 
 @dataclass
@@ -292,6 +415,7 @@ class IPMDConfig(PPOConfig):
                 f"{self.latent_steps_min} > {self.latent_steps_max}."
             )
             raise ValueError(msg)
+        self.latent_learning.validate(command_dim=self.latent_dim)
         require_non_negative("ipmd.diversity_bonus_coeff", self.diversity_bonus_coeff)
         require_non_negative("ipmd.diversity_target", self.diversity_target)
         if float(self.latent_uniformity_temperature) <= 0.0:
@@ -597,11 +721,15 @@ class IPMD(PPO):
             return
 
         assert self._latent_learner is not None
-        latents = self._latent_learner.infer_batch_latents(
-            td,
-            detach=True,
-            context="collector posterior latent",
-        )
+        collector_hook = getattr(self._latent_learner, "infer_collector_latents", None)
+        if callable(collector_hook):
+            latents = collector_hook(td)
+        else:
+            latents = self._latent_learner.infer_batch_latents(
+                td,
+                detach=True,
+                context="collector posterior latent",
+            )
         if latents is None:
             msg = (
                 "Active latent learner does not support collector-time posterior "
@@ -1206,14 +1334,34 @@ class IPMD(PPO):
         self.collector.update_policy_weights_()
         self._refresh_progress_display(metadata, iteration)
 
-        if (
-            self.config.save_interval > 0
-            and metadata.frames_processed > 0
-            and metadata.frames_processed % self.config.save_interval == 0
+        if self._should_save_checkpoint(
+            frames_processed=metadata.frames_processed,
+            frames_in_iteration=iteration.frames,
         ):
             self.save_model(
                 path=self.log_dir / self.config.logger.save_path,
                 step=metadata.frames_processed,
+            )
+
+    def _extra_model_state_dict(self) -> dict[str, Any]:
+        ipmd_state: dict[str, Any] = {
+            "reward_estimator_state_dict": self.reward_estimator.state_dict(),
+        }
+        if self._latent_learner is not None:
+            ipmd_state["latent_learner_state_dict"] = (
+                self._latent_learner.checkpoint_state_dict()
+            )
+        return {"ipmd_state": ipmd_state}
+
+    def _load_extra_model_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+        ipmd_state = checkpoint.get("ipmd_state")
+        if ipmd_state is None:
+            return
+        ipmd_state = cast(dict[str, Any], ipmd_state)
+        self.reward_estimator.load_state_dict(ipmd_state["reward_estimator_state_dict"])
+        if self._latent_learner is not None:
+            self._latent_learner.load_checkpoint_state_dict(
+                cast(dict[str, Any], ipmd_state["latent_learner_state_dict"])
             )
 
     def predict(self, obs: Tensor | np.ndarray | Mapping[Any, Any]) -> Tensor:  # type: ignore[override]

--- a/rlopt/agent/ipmd/ipmd_diffsr.py
+++ b/rlopt/agent/ipmd/ipmd_diffsr.py
@@ -501,10 +501,10 @@ class IPMDDiffSR(IPMD):
                     pbar.set_postfix(postfix)
 
             if (
-                self.config.save_interval > 0
-                and collected_frames
-                % (self.config.save_interval * self.config.env.num_envs)
-                == 0
+                self._should_save_checkpoint(
+                    frames_processed=collected_frames,
+                    frames_in_iteration=frames_in_batch,
+                )
             ):
                 self.save_model(
                     path=self.log_dir / self.config.logger.save_path,

--- a/rlopt/agent/l2t/l2t.py
+++ b/rlopt/agent/l2t/l2t.py
@@ -1012,8 +1012,10 @@ class L2T(BaseAlgorithm[L2TRLOptConfig]):
 
             # Save model periodically
             if (
-                self.config.save_interval > 0
-                and collected_frames % self.config.save_interval == 0
+                self._should_save_checkpoint(
+                    frames_processed=collected_frames,
+                    frames_in_iteration=frames_in_batch,
+                )
             ):
                 self.save_model(step=collected_frames)
 

--- a/rlopt/agent/ppo/ppo.py
+++ b/rlopt/agent/ppo/ppo.py
@@ -757,9 +757,10 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         self._refresh_progress_display(metadata, iteration)
 
         if (
-            self.config.save_interval > 0
-            and metadata.frames_processed > 0
-            and metadata.frames_processed % self.config.save_interval == 0
+            self._should_save_checkpoint(
+                frames_processed=metadata.frames_processed,
+                frames_in_iteration=iteration.frames,
+            )
         ):
             checkpoint_dir = self.log_dir / self.config.logger.save_path
             custom_save = getattr(self, "save", None)

--- a/rlopt/agent/sac/fastsac.py
+++ b/rlopt/agent/sac/fastsac.py
@@ -1098,9 +1098,10 @@ class FastSAC(BaseAlgorithm[FastSACRLOptConfig]):
 
         # save_interval is in *samples* (same unit as log_interval and total_frames).
         if (
-            cfg.save_interval > 0
-            and metadata.frames_processed > 0
-            and metadata.frames_processed % cfg.save_interval == 0
+            self._should_save_checkpoint(
+                frames_processed=metadata.frames_processed,
+                frames_in_iteration=iteration.frames,
+            )
         ):
             self.save_model(
                 path=self.log_dir / cfg.logger.save_path,

--- a/rlopt/agent/sac/sac.py
+++ b/rlopt/agent/sac/sac.py
@@ -691,9 +691,10 @@ class SAC(BaseAlgorithm[SACRLOptConfig]):
 
                 # Save model periodically (save_interval is in samples)
                 if (
-                    self.config.save_interval > 0
-                    and collected_frames > 0
-                    and collected_frames % self.config.save_interval == 0
+                    self._should_save_checkpoint(
+                        frames_processed=collected_frames,
+                        frames_in_iteration=frames_in_batch,
+                    )
                 ):
                     self.save_model(
                         path=self.log_dir / self.config.logger.save_path,

--- a/rlopt/base_class.py
+++ b/rlopt/base_class.py
@@ -971,6 +971,7 @@ class BaseAlgorithm(Generic[CfgT], ABC):
             and hasattr(self.env, "normalize_obs")
         ):
             data_to_save["vec_norm_msg"] = self.env.state_dict()
+        data_to_save.update(self._extra_model_state_dict())
 
         torch.save(data_to_save, target_path)
 
@@ -1006,6 +1007,31 @@ class BaseAlgorithm(Generic[CfgT], ABC):
             self.feature_extractor.load_state_dict(data["feature_extractor_state_dict"])  # type: ignore[arg-type]
         if hasattr(self.env, "normalize_obs") and "vec_norm_msg" in data:
             self.env.load_state_dict(data["vec_norm_msg"])  # type: ignore[arg-type]
+        self._load_extra_model_state_dict(data)
+
+    def _extra_model_state_dict(self) -> dict[str, Any]:
+        """Algorithm-specific checkpoint payload, merged into ``save_model``."""
+        return {}
+
+    def _load_extra_model_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+        del checkpoint
+
+    def _should_save_checkpoint(
+        self,
+        *,
+        frames_processed: int,
+        frames_in_iteration: int,
+    ) -> bool:
+        """Return true once when an iteration crosses a sample-count boundary."""
+        save_interval = int(self.config.save_interval)
+        if save_interval <= 0:
+            return False
+        current_frames = int(frames_processed)
+        previous_frames = current_frames - int(frames_in_iteration)
+        return (
+            current_frames >= save_interval
+            and current_frames // save_interval > previous_frames // save_interval
+        )
 
     def _refresh_parameter_monitor(self) -> None:
         """Build a registry of all trainable parameters for numerical stability monitoring.

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -395,4 +395,4 @@ class RLOptConfig:
     """Verbosity for internal debug logging (e.g. ``"debug"``, ``"info"``)."""
 
     save_interval: int = 10
-    """Interval for saving the model."""
+    """Environment-sample interval for model checkpoints. 0 disables saving."""

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -254,6 +254,29 @@ def test_ipmd_latent_mode_owns_controller_without_mixin_inheritance():
     assert not isinstance(agent, LatentCommandMixin)
 
 
+def test_ipmd_checkpoint_cadence_crosses_sample_boundary_once() -> None:
+    """Checkpoint cadence should trigger when an iteration crosses save_interval."""
+    agent, _ = _make_env_reward_only_ipmd_agent()
+    agent.config.save_interval = 100
+
+    assert not agent._should_save_checkpoint(
+        frames_processed=99,
+        frames_in_iteration=4,
+    )
+    assert agent._should_save_checkpoint(
+        frames_processed=100,
+        frames_in_iteration=4,
+    )
+    assert not agent._should_save_checkpoint(
+        frames_processed=120,
+        frames_in_iteration=20,
+    )
+    assert agent._should_save_checkpoint(
+        frames_processed=205,
+        frames_in_iteration=90,
+    )
+
+
 def test_ipmd_reward_estimator():
     """Test IPMD reward estimator network."""
     rlopt = _rlopt()
@@ -504,7 +527,9 @@ def test_ipmd_sampler_missing_required_keys_raises() -> None:
     )
 
     def _sample(_batch_size: int, required_keys):
-        return expert_data.select(*(key for key in required_keys if key in expert_data.keys(True))).clone()
+        return expert_data.select(
+            *(key for key in required_keys if key in expert_data.keys(True))
+        ).clone()
 
     agent._set_test_expert_batch_sampler(_sample)
 
@@ -619,6 +644,100 @@ def test_ipmd_posterior_collector_latents_are_recomputed_each_step() -> None:
         rollout_td_1.get("observation"),
         rollout_td_2.get("observation"),
     )
+
+
+def test_ipmd_vqvae_phase_config_validates_command_width() -> None:
+    """VQVAE code width plus phase features should be validated up front."""
+    rlopt = _rlopt()
+    cfg = rlopt.IPMDRLOptConfig()
+    cfg.ipmd.latent_dim = 66
+    cfg.ipmd.latent_learning.command_phase_mode = "sin_cos"
+    cfg.ipmd.latent_learning.code_latent_dim = 64
+    cfg.ipmd.validate()
+
+    bad_cfg = rlopt.IPMDRLOptConfig()
+    bad_cfg.ipmd.latent_dim = 65
+    bad_cfg.ipmd.latent_learning.command_phase_mode = "sin_cos"
+    bad_cfg.ipmd.latent_learning.code_latent_dim = 64
+    with pytest.raises(ValueError, match="code_latent_dim plus phase"):
+        bad_cfg.ipmd.validate()
+
+    bad_quantizer = rlopt.IPMDRLOptConfig()
+    bad_quantizer.ipmd.latent_learning.quantizer = "not_a_quantizer"
+    with pytest.raises(ValueError, match="quantizer"):
+        bad_quantizer.ipmd.validate()
+
+
+def test_fsq_quantizer_uses_all_even_level_codes() -> None:
+    """Even FSQ levels should map to all integer bins without half-step collapse."""
+    from rlopt.agent.imitation.latent_learning import FSQQuantizer
+
+    quantizer = FSQQuantizer([8])
+    z_e = torch.linspace(-20.0, 20.0, steps=4096).unsqueeze(-1)
+    _, code, _ = quantizer(z_e)
+
+    assert torch.equal(torch.unique(code), torch.arange(8))
+
+
+def test_patch_vqvae_collector_holds_code_and_reports_phase() -> None:
+    """The collector hook should hold z_q while sin/cos phase advances."""
+    rlopt = _rlopt()
+    from rlopt.agent.imitation.latent_learning import PatchVQVAELatentLearner
+
+    cfg = rlopt.IPMDRLOptConfig()
+    cfg.ipmd.latent_dim = 5
+    cfg.ipmd.latent_learning.method = "patch_vqvae"
+    cfg.ipmd.latent_learning.quantizer = "identity"
+    cfg.ipmd.latent_learning.code_latent_dim = 3
+    cfg.ipmd.latent_learning.command_phase_mode = "sin_cos"
+    cfg.ipmd.latent_learning.code_period = 3
+    cfg.ipmd.latent_learning.posterior_input_keys = ["observation"]
+    cfg.ipmd.validate()
+
+    fake_agent = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _latent_dim=5,
+        _obs_feature_dims={"observation": 3},
+        _posterior_obs_keys=["observation"],
+        _action_feature_dim=2,
+    )
+    learner = PatchVQVAELatentLearner()
+    learner.initialize(fake_agent)
+    learner.encoder = torch.nn.Identity()
+
+    td0 = TensorDict(
+        {"observation": torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])},
+        batch_size=[2],
+    )
+    td1 = TensorDict(
+        {"observation": torch.tensor([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]])},
+        batch_size=[2],
+    )
+    td3 = TensorDict(
+        {"observation": torch.tensor([[7.0, 8.0, 9.0], [1.0, 3.0, 5.0]])},
+        batch_size=[2],
+    )
+
+    cmd0 = learner.infer_collector_latents(td0)
+    cmd1 = learner.infer_collector_latents(td1)
+    cmd2 = learner.infer_collector_latents(td1)
+    cmd3 = learner.infer_collector_latents(td3)
+
+    assert torch.allclose(cmd0[:, :3], td0["observation"])
+    assert torch.allclose(cmd1[:, :3], td0["observation"])
+    assert torch.allclose(cmd2[:, :3], td0["observation"])
+    assert torch.allclose(cmd3[:, :3], td3["observation"])
+
+    phase0 = torch.tensor([0.0, 1.0]).repeat(2, 1)
+    angle1 = torch.tensor(2.0 * torch.pi / 3.0)
+    phase1 = torch.stack((torch.sin(angle1), torch.cos(angle1))).repeat(2, 1)
+    angle2 = torch.tensor(4.0 * torch.pi / 3.0)
+    phase2 = torch.stack((torch.sin(angle2), torch.cos(angle2))).repeat(2, 1)
+    assert torch.allclose(cmd0[:, -2:], phase0)
+    assert torch.allclose(cmd1[:, -2:], phase1)
+    assert torch.allclose(cmd2[:, -2:], phase2)
+    assert torch.allclose(cmd3[:, -2:], phase0)
 
 
 def test_ipmd_patch_autoencoder_uses_only_posterior_expert_keys() -> None:


### PR DESCRIPTION
## Summary
- Add `patch_vqvae` latent learner with FSQ, EMA VQ, Gumbel, and identity quantizer paths.
- Add temporal code holding with optional sin/cos phase commands for posterior IPMD collection.
- Save IPMD reward-estimator and latent-learner state in checkpoints, and unify checkpoint cadence on environment-sample boundaries.
- Add focused IPMD/VQVAE tests and a VQVAE skill-codebook report.

## Validation
- `python -m pytest tests/test_ipmd_components.py -q` -> 23 passed.
- `ruff check` and `ruff format --check` on touched RLOpt Python files -> passed.
- `py_compile` on touched RLOpt Python files -> passed.
- Claude review found an FSQ even-level code-id bug; fixed and re-reviewed with no blocking findings.

## Notes
- `save_interval` is now documented and applied as an environment-sample interval across algorithms touched here.
- Variable-duration boundary work is intentionally not included in this PR.