### PR TITLE
[codex] Restore bilinear feature-only policy defaults

### DIFF
--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -12,7 +12,6 @@ The spectral representation objective is configurable via ``sr_type``:
 
 from __future__ import annotations
 
-import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -42,6 +41,7 @@ from rlopt.config_utils import (
     dedupe_keys,
     next_obs_key,
     normalize_batch_key,
+    obs_key_feature_dim,
 )
 from rlopt.models.gaussian_policy import GaussianPolicyHead
 from rlopt.utils import get_activation_class
@@ -520,10 +520,7 @@ class IPMDBilinear(IPMD):
         else:
             command_keys = self._bilinear_policy_command_keys()
             command_dim = (
-                sum(
-                    int(math.prod(self.env.observation_spec[key].shape))
-                    for key in command_keys
-                )
+                sum(obs_key_feature_dim(self.env, key) for key in command_keys)
                 if command_keys
                 else None
             )

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -12,30 +12,95 @@ The spectral representation objective is configurable via ``sr_type``:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
 
 import torch
-import torch.nn.functional as F
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
-from torch import Tensor, nn
-from torchrl.data import LazyTensorStorage, ReplayBuffer, TensorDictReplayBuffer
+from torch import Tensor
+from torchrl.data import (
+    Bounded,
+    LazyTensorStorage,
+    ReplayBuffer,
+    TensorDictReplayBuffer,
+)
 from torchrl.data.replay_buffers.samplers import RandomSampler
 from torchrl.envs.utils import ExplorationType
-from torchrl.modules import MLP, ProbabilisticActor, TanhNormal
+from torchrl.modules import MLP, IndependentNormal, ProbabilisticActor, TanhNormal
 from torchrl.record.loggers import Logger
 
 from rlopt.agent.ipmd.ipmd import IPMD, IPMDRLOptConfig
 from rlopt.agent.ipmd.module import BilinearSR, build_bilinear_sr
+from rlopt.agent.ipmd.utils import require_positive_int
+from rlopt.agent.ppo.ppo import PPOIterationData, PPOTrainingMetadata
+from rlopt.config_utils import (
+    BatchKey,
+    ObsKey,
+    dedupe_keys,
+    next_obs_key,
+    normalize_batch_key,
+)
 from rlopt.models.gaussian_policy import GaussianPolicyHead
 from rlopt.utils import get_activation_class
-from rlopt.agent.ppo.ppo import PPOIterationData, PPOTrainingMetadata
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
+
+
+DEFAULT_BILINEAR_OBS_KEYS: list[ObsKey] = [
+    ("policy", "base_ang_vel"),
+    ("policy", "joint_pos_rel"),
+    ("policy", "joint_vel_rel"),
+    ("policy", "last_action"),
+]
+
+DEFAULT_BILINEAR_NEXT_OBS_KEYS: list[ObsKey] = [
+    ("policy", "base_ang_vel"),
+    ("policy", "joint_pos_rel"),
+    ("policy", "joint_vel_rel"),
+]
+
+
+def _require_non_negative_int(name: str, value: int) -> int:
+    normalized = int(value)
+    if normalized < 0:
+        msg = f"{name} must be >= 0, got {value!r}."
+        raise ValueError(msg)
+    return normalized
+
+
+@dataclass
+class BilinearOfflinePretrainConfig:
+    """Offline spectral-representation pretraining configuration."""
+
+    enabled: bool = False
+    """Run offline SR pretraining before online rollout collection."""
+
+    num_updates: int = 2000
+    """Number of offline SR gradient updates."""
+
+    batch_size: int = 8192
+    """Expert transition batch size sampled per offline SR update."""
+
+    log_interval: int = 100
+    """Log offline SR metrics every N offline updates."""
+
+    def validate(self) -> None:
+        if not self.enabled:
+            return
+        self.num_updates = require_positive_int(
+            "bilinear.offline_pretrain.num_updates", self.num_updates
+        )
+        self.batch_size = require_positive_int(
+            "bilinear.offline_pretrain.batch_size", self.batch_size
+        )
+        self.log_interval = require_positive_int(
+            "bilinear.offline_pretrain.log_interval", self.log_interval
+        )
 
 
 @dataclass
@@ -54,10 +119,10 @@ class BilinearSRConfig:
     f_hidden_dims: tuple[int, ...] = (512, 512)
     """Hidden layers for state encoder f(s)."""
 
-    g_hidden_dims: tuple[int, ...] = (512, )
+    g_hidden_dims: tuple[int, ...] = (512,)
     """Hidden layers for action encoder g(a)."""
 
-    mu_hidden_dims: tuple[int, ...] = (512, )
+    mu_hidden_dims: tuple[int, ...] = (512,)
     """Hidden layers for next-state encoder mu(s')."""
 
     feature_lr: float = 1e-4
@@ -99,20 +164,57 @@ class BilinearSRConfig:
     use_ema_for_policy: bool = True
     """Use a slow-moving EMA copy of state_net for policy input (stabilizes PPO)."""
 
-    def get_obs_keys(self):
-        return [
-            ("policy", "base_ang_vel"), 
-            ("policy", "joint_pos_rel"), 
-            ("policy", "joint_vel_rel"), 
-            ("policy", "last_action"),
-        ]
-    
-    def get_next_obs_keys(self):
-        return [
-            ("policy", "base_ang_vel"), 
-            ("policy", "joint_pos_rel"), 
-            ("policy", "joint_vel_rel"), 
-        ]
+    obs_keys: list[ObsKey] = field(
+        default_factory=lambda: list(DEFAULT_BILINEAR_OBS_KEYS)
+    )
+    """Observation keys concatenated into the SR state input s."""
+
+    next_obs_keys: list[ObsKey] = field(
+        default_factory=lambda: list(DEFAULT_BILINEAR_NEXT_OBS_KEYS)
+    )
+    """Observation keys concatenated into the SR next-state input s'."""
+
+    offline_pretrain: BilinearOfflinePretrainConfig = field(
+        default_factory=BilinearOfflinePretrainConfig
+    )
+    """Offline SR pretraining settings."""
+
+    def validate(self) -> None:
+        self.sr_type = str(self.sr_type).strip().lower()
+        self.feature_dim = require_positive_int(
+            "bilinear.feature_dim", self.feature_dim
+        )
+        self.embed_dim = require_positive_int("bilinear.embed_dim", self.embed_dim)
+        self.update_steps = _require_non_negative_int(
+            "bilinear.update_steps", self.update_steps
+        )
+        self.history_buffer_size = require_positive_int(
+            "bilinear.history_buffer_size", self.history_buffer_size
+        )
+        self.sr_batch_size = require_positive_int(
+            "bilinear.sr_batch_size", self.sr_batch_size
+        )
+        self.num_noises = _require_non_negative_int(
+            "bilinear.num_noises", self.num_noises
+        )
+        self.obs_keys = cast(list[ObsKey], dedupe_keys(list(self.obs_keys)))
+        self.next_obs_keys = cast(list[ObsKey], dedupe_keys(list(self.next_obs_keys)))
+        if len(self.obs_keys) == 0:
+            msg = "bilinear.obs_keys must be non-empty."
+            raise ValueError(msg)
+        if self.offline_pretrain.enabled and len(self.next_obs_keys) == 0:
+            msg = (
+                "bilinear.offline_pretrain.enabled=True requires non-empty "
+                "bilinear.next_obs_keys."
+            )
+            raise ValueError(msg)
+        self.offline_pretrain.validate()
+
+    def get_obs_keys(self) -> list[ObsKey]:
+        return list(self.obs_keys)
+
+    def get_next_obs_keys(self) -> list[ObsKey]:
+        return list(self.next_obs_keys)
 
 
 @dataclass
@@ -123,6 +225,8 @@ class IPMDBilinearRLOptConfig(IPMDRLOptConfig):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self.bilinear.validate()
+
 
 # ---------------------------------------------------------------------------
 # Policy Head
@@ -147,6 +251,8 @@ class BilinearPolicyHead(GaussianPolicyHead):
         num_cells: list[int],
         activation_fn: str,
         action_dim: int,
+        num_command_inputs: int,
+        command_dim: int | None,
         log_std_init: float = 0.0,
         log_std_min: float = -20.0,
         log_std_max: float = 2.0,
@@ -176,22 +282,59 @@ class BilinearPolicyHead(GaussianPolicyHead):
         # Detach prevents PPO gradients flowing into the representation.
         self.bilinear_rep = bilinear_rep
         self.detach_features = detach_features
+        self.num_command_inputs = int(num_command_inputs)
+        if self.num_command_inputs < 0:
+            msg = "num_command_inputs must be >= 0."
+            raise ValueError(msg)
+        if self.num_command_inputs == 0:
+            if command_dim is not None:
+                msg = "command_dim must be None when num_command_inputs is 0."
+                raise ValueError(msg)
+            self.command_projector = None
+        else:
+            if command_dim is None or command_dim <= 0:
+                msg = "command_dim must be positive when command inputs are present."
+                raise ValueError(msg)
+            self.command_projector = (
+                None
+                if command_dim == bilinear_rep.feature_dim
+                else torch.nn.Linear(
+                    command_dim, bilinear_rep.feature_dim, device=device
+                )
+            )
 
     def forward(self, *obs: Tensor) -> tuple[Tensor, Tensor]:
         """Compute (loc, scale) from observations via bilinear representation.
 
-        1. Concatenate multi-key observations.
-        2. Compute policy representation f(s) @ W(z).
+        1. Split command observations from representation-state observations.
+        2. Project command observations into the spectral coefficient space.
+        3. Compute policy representation f(s) @ W(z).
         3. (Optionally) detach from SR computation graph.
         4. Feed through base MLP -> loc, then log_std_module -> scale.
         """
-        if len(obs) == 0:
-            raise ValueError(
-                "BilinearPolicyHead.forward() expected at least one observation tensor."
+        if len(obs) <= self.num_command_inputs:
+            msg = (
+                "BilinearPolicyHead.forward() expected representation-state "
+                "observations after the configured command inputs."
             )
-        z, *obs = obs
-        combined = obs[0] if len(obs) == 1 else torch.cat(obs, dim=-1)
-        rep = self.bilinear_rep.compute_policy_representation(combined, z)
+            raise ValueError(msg)
+        command_obs = obs[: self.num_command_inputs]
+        state_obs = obs[self.num_command_inputs :]
+        state = state_obs[0] if len(state_obs) == 1 else torch.cat(state_obs, dim=-1)
+        if len(command_obs) == 0:
+            z = state.new_ones((*state.shape[:-1], self.bilinear_rep.feature_dim))
+        else:
+            command = (
+                command_obs[0]
+                if len(command_obs) == 1
+                else torch.cat(command_obs, dim=-1)
+            )
+            if command.shape[-1] == self.bilinear_rep.feature_dim:
+                z = command
+            else:
+                assert self.command_projector is not None
+                z = self.command_projector(command)
+        rep = self.bilinear_rep.compute_policy_representation(state, z)
         # if self.detach_features:
         #     rep = rep.detach()
         # Delegate to GaussianPolicyHead: base MLP + log_std_module
@@ -226,7 +369,18 @@ class IPMDBilinear(IPMD):
         **kwargs,
     ) -> None:
         self.config = cast(IPMDBilinearRLOptConfig, config)
+        self.config.bilinear.validate()
         self.env = env
+        self._provided_bilinear_policy_net = policy_net
+        if (
+            self.config.bilinear.offline_pretrain.enabled
+            and self._discover_env_method(env, "sample_expert_batch") is None
+        ):
+            msg = (
+                "bilinear.offline_pretrain.enabled=True requires "
+                "env.sample_expert_batch(...)."
+            )
+            raise ValueError(msg)
 
         # Build before super().__init__ so _construct_policy can use it.
         self._bilinear_obs_keys = self.config.bilinear.get_obs_keys()
@@ -260,39 +414,58 @@ class IPMDBilinear(IPMD):
             sampler=RandomSampler(),
             batch_size=self.config.bilinear.sr_batch_size,
         )
+        self._validate_offline_pretrain_setup()
 
     # -- Construction --
 
+    @staticmethod
+    def _get_batch_key(td: TensorDict, key: BatchKey) -> Tensor:
+        return cast(Tensor, td.get(key))
+
+    @staticmethod
+    def _offline_next_key(key: ObsKey) -> tuple[str, ...]:
+        return next_obs_key(key)
+
     def _concat_bilinear_obs_from_td(self, td: TensorDict) -> Tensor:
         """Concatenate all policy obs keys from a TensorDict."""
-        parts = [td.get(k).flatten(-1) for k in self._bilinear_obs_keys]
+        parts = [
+            self._get_batch_key(td, k).flatten(-1) for k in self._bilinear_obs_keys
+        ]
         return parts[0] if len(parts) == 1 else torch.cat(parts, dim=-1)
 
     def _concat_bilinear_next_obs_from_td(self, td: TensorDict) -> Tensor:
         """Concatenate all next policy obs keys from a TensorDict."""
-        parts = [td.get(("next", k)).flatten(-1) for k in self._bilinear_next_obs_keys]
+        parts = [
+            self._get_batch_key(td, self._offline_next_key(k)).flatten(-1)
+            for k in self._bilinear_next_obs_keys
+        ]
         return parts[0] if len(parts) == 1 else torch.cat(parts, dim=-1)
 
     def _construct_bilinear_model(self) -> BilinearSR:
         cfg = self.config.bilinear
         action_spec = getattr(self.env, "action_spec_unbatched", self.env.action_spec)
-        bilinear_obs_dim = sum(int(self.env.observation_spec[k].shape[-1]) for k in self._bilinear_obs_keys)
-        bilinear_next_obs_dim = sum(int(self.env.observation_spec[k].shape[-1]) for k in self._bilinear_next_obs_keys)
+        bilinear_obs_dim = sum(
+            int(self.env.observation_spec[k].shape[-1]) for k in self._bilinear_obs_keys
+        )
+        bilinear_next_obs_dim = sum(
+            int(self.env.observation_spec[k].shape[-1])
+            for k in self._bilinear_next_obs_keys
+        )
 
         # Common kwargs shared by all SR types
-        common = dict(
-            obs_dim=bilinear_obs_dim,
-            next_obs_dim=bilinear_next_obs_dim,
-            action_dim=action_spec.shape[-1],
-            feature_dim=cfg.feature_dim,
-            embed_dim=cfg.embed_dim,
-            f_hidden_dims=cfg.f_hidden_dims,
-            g_hidden_dims=cfg.g_hidden_dims,
-            mu_hidden_dims=cfg.mu_hidden_dims,
-            num_noises=cfg.num_noises,
-            use_ema_for_policy=cfg.use_ema_for_policy,
-            device=self.device,
-        )
+        common = {
+            "obs_dim": bilinear_obs_dim,
+            "next_obs_dim": bilinear_next_obs_dim,
+            "action_dim": action_spec.shape[-1],
+            "feature_dim": cfg.feature_dim,
+            "embed_dim": cfg.embed_dim,
+            "f_hidden_dims": cfg.f_hidden_dims,
+            "g_hidden_dims": cfg.g_hidden_dims,
+            "mu_hidden_dims": cfg.mu_hidden_dims,
+            "num_noises": cfg.num_noises,
+            "use_ema_for_policy": cfg.use_ema_for_policy,
+            "device": self.device,
+        }
 
         # Type-specific kwargs
         if cfg.sr_type == "diffsr":
@@ -302,11 +475,29 @@ class IPMDBilinear(IPMD):
 
         return build_bilinear_sr(cfg.sr_type, **common)
 
+    def _validate_offline_pretrain_setup(self) -> None:
+        offline_cfg = self.config.bilinear.offline_pretrain
+        if not offline_cfg.enabled:
+            return
+        if self._expert_batch_sampler is None:
+            msg = (
+                "bilinear.offline_pretrain.enabled=True requires "
+                "env.sample_expert_batch(...)."
+            )
+            raise ValueError(msg)
+        offline_cfg.validate()
+
+    def _bilinear_policy_command_keys(self) -> list[ObsKey]:
+        bilinear_state_keys = set(self._bilinear_obs_keys)
+        return [
+            cast(ObsKey, normalize_batch_key(key))
+            for key in self.config.policy.get_input_keys()
+            if normalize_batch_key(key) not in bilinear_state_keys
+        ]
+
     def _construct_policy(
         self, policy_net: torch.nn.Module | None = None
     ) -> TensorDictModule:
-        from torchrl.data import Bounded
-
         action_spec = self.env.action_spec_unbatched
         action_dim = int(action_spec.shape[-1])
 
@@ -320,27 +511,42 @@ class IPMDBilinear(IPMD):
                 },
             )
         else:
-            from torchrl.modules import IndependentNormal
-
             dist_cls, dist_kw = IndependentNormal, {}
 
-        policy_head = policy_net or BilinearPolicyHead(
-            bilinear_rep=self.bilinear_rep,
-            num_cells=list(self.config.policy.num_cells),
-            activation_fn=self.config.policy.activation_fn,
-            action_dim=action_dim,
-            log_std_init=self.config.ppo.log_std_init,
-            log_std_min=self.config.ppo.log_std_min,
-            log_std_max=self.config.ppo.log_std_max,
-            clip_log_std=self.config.ppo.clip_log_std,
-            detach_features=self.config.bilinear.detach_features_for_policy,
-            device=self.device,
-        )
+        provided_policy_head = policy_net or self._provided_bilinear_policy_net
+        if provided_policy_head is not None:
+            policy_head = provided_policy_head
+            policy_in_keys = self.config.policy.get_input_keys()
+        else:
+            command_keys = self._bilinear_policy_command_keys()
+            command_dim = (
+                sum(
+                    int(math.prod(self.env.observation_spec[key].shape))
+                    for key in command_keys
+                )
+                if command_keys
+                else None
+            )
+            policy_head = BilinearPolicyHead(
+                bilinear_rep=self.bilinear_rep,
+                num_cells=list(self.config.policy.num_cells),
+                activation_fn=self.config.policy.activation_fn,
+                action_dim=action_dim,
+                num_command_inputs=len(command_keys),
+                command_dim=command_dim,
+                log_std_init=self.config.ppo.log_std_init,
+                log_std_min=self.config.ppo.log_std_min,
+                log_std_max=self.config.ppo.log_std_max,
+                clip_log_std=self.config.ppo.clip_log_std,
+                detach_features=self.config.bilinear.detach_features_for_policy,
+                device=self.device,
+            )
+            policy_in_keys = command_keys + list(self._bilinear_obs_keys)
 
         return ProbabilisticActor(
             TensorDictModule(
                 policy_head,
-                in_keys=self.config.policy.get_input_keys(),
+                in_keys=policy_in_keys,
                 out_keys=["loc", "scale"],
             ),
             in_keys=["loc", "scale"],
@@ -353,17 +559,34 @@ class IPMDBilinear(IPMD):
 
     # -- SR training --
 
-    def _store_transitions(self, batch: TensorDict) -> None:
+    def _sr_transition_batch_from_td(
+        self,
+        batch: TensorDict,
+        *,
+        action_key: BatchKey,
+    ) -> TensorDict:
         obs = self._concat_bilinear_obs_from_td(batch)
         next_obs = self._concat_bilinear_next_obs_from_td(batch)
+        action = self._get_batch_key(batch, action_key)
 
-        transitions = TensorDict(
+        return TensorDict(
             {
                 "obs": obs,
-                "action": batch.get("action"),
+                "action": action,
                 ("next", "obs"): next_obs,
             },
             batch_size=batch.batch_size,
+        )
+
+    def _store_transitions(
+        self,
+        batch: TensorDict,
+        *,
+        action_key: BatchKey = "action",
+    ) -> None:
+        transitions = self._sr_transition_batch_from_td(
+            batch,
+            action_key=action_key,
         )
         self._sr_history_buffer.extend(transitions.reshape(-1).detach())
 
@@ -371,6 +594,14 @@ class IPMDBilinear(IPMD):
         n = len(self._sr_history_buffer)
         all_next_obs = self._sr_history_buffer._storage._storage["next", "obs"][:n]
         self.bilinear_rep.update_obs_norm(all_next_obs)
+
+    def _offline_sr_required_keys(self) -> list[BatchKey]:
+        required: list[BatchKey] = list(self._bilinear_obs_keys)
+        required.extend(
+            self._offline_next_key(key) for key in self._bilinear_next_obs_keys
+        )
+        required.append("expert_action")
+        return dedupe_keys(required)
 
     def _sr_loss_from_batch(self, batch: TensorDict) -> tuple[dict[str, float], Tensor]:
         batch = batch.to(self.device)
@@ -434,12 +665,64 @@ class IPMDBilinear(IPMD):
             "sample/recon_l1": l1.item(),
         }
 
+    def _offline_pretrain_spectral_representation(self) -> None:
+        offline_cfg = self.config.bilinear.offline_pretrain
+        if not offline_cfg.enabled:
+            return
+
+        required_keys = self._offline_sr_required_keys()
+        for update_idx in range(1, offline_cfg.num_updates + 1):
+            expert_batch = self._next_expert_batch(
+                batch_size=offline_cfg.batch_size,
+                required_keys=required_keys,
+            )
+            self._store_transitions(expert_batch, action_key="expert_action")
+            sr_metrics = self._train_sr_steps(1)
+
+            if update_idx % offline_cfg.log_interval == 0 or update_idx in {
+                1,
+                offline_cfg.num_updates,
+            }:
+                log_metrics = {
+                    f"offline/sr/{key}": value for key, value in sr_metrics.items()
+                }
+                log_metrics["offline/sr/history_buffer_size"] = float(
+                    len(self._sr_history_buffer)
+                )
+                self.log_metrics(
+                    log_metrics,
+                    step=update_idx,
+                    log_python=bool(self.config.logger.log_to_console),
+                )
+
+        self.bilinear_rep.update_ema(1.0)
+
+    def train(self) -> None:  # type: ignore[override]
+        """Run offline SR pretraining, then the normal online IPMD loop."""
+        self.validate_training()
+        self._offline_pretrain_spectral_representation()
+        metadata = self.init_metadata()
+
+        try:
+            for iteration_idx in range(metadata.total_iterations):
+                iteration = self.collect(metadata, iteration_idx)
+                self.prepare(iteration, metadata)
+                self.iterate(iteration, metadata)
+                self.record(iteration, metadata)
+        finally:
+            metadata.progress_bar.close()  # type: ignore[attr-defined]
+            self.collector.shutdown()
+
     # -- Update / logging overrides --
-    def prepare(self, iteration: PPOIterationData, metadata: PPOTrainingMetadata) -> None:
+    def prepare(
+        self, iteration: PPOIterationData, metadata: PPOTrainingMetadata
+    ) -> None:
         super().prepare(iteration, metadata)
         self._store_transitions(iteration.rollout)
-        
-    def iterate(self, iteration: PPOIterationData, metadata: PPOTrainingMetadata) -> None:
+
+    def iterate(
+        self, iteration: PPOIterationData, metadata: PPOTrainingMetadata
+    ) -> None:
         super().iterate(iteration, metadata)
 
         sr_metrics = self._train_sr_steps(self.config.bilinear.update_steps)
@@ -449,10 +732,18 @@ class IPMDBilinear(IPMD):
             self._pending_sr_metrics.setdefault(k, []).append(v)
 
         self._pending_sr_metrics.setdefault("z_l1_mean", []).append(
-            iteration.rollout.get(self._latent_key).reshape(-1, self._latent_dim).abs().mean().item()
+            iteration.rollout.get(self._latent_key)
+            .reshape(-1, self._latent_dim)
+            .abs()
+            .mean()
+            .item()
         )
         self._pending_sr_metrics.setdefault("z_l1_std", []).append(
-            iteration.rollout.get(self._latent_key).reshape(-1, self._latent_dim).std(dim=0).mean().item()
+            iteration.rollout.get(self._latent_key)
+            .reshape(-1, self._latent_dim)
+            .std(dim=0)
+            .mean()
+            .item()
         )
         self._pending_sr_metrics.setdefault("history_buffer_size", []).append(
             float(len(self._sr_history_buffer))

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -12,6 +12,7 @@ The spectral representation objective is configurable via ``sr_type``:
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -89,6 +90,12 @@ class BilinearOfflinePretrainConfig:
     log_interval: int = 100
     """Log offline SR metrics every N offline updates."""
 
+    policy_bc_updates: int = 0
+    """Number of offline policy behavior-cloning updates after SR pretraining."""
+
+    policy_bc_batch_size: int = 8192
+    """Expert action batch size for offline policy BC."""
+
     def validate(self) -> None:
         if not self.enabled:
             return
@@ -101,6 +108,15 @@ class BilinearOfflinePretrainConfig:
         self.log_interval = require_positive_int(
             "bilinear.offline_pretrain.log_interval", self.log_interval
         )
+        self.policy_bc_updates = _require_non_negative_int(
+            "bilinear.offline_pretrain.policy_bc_updates",
+            self.policy_bc_updates,
+        )
+        if self.policy_bc_updates > 0:
+            self.policy_bc_batch_size = require_positive_int(
+                "bilinear.offline_pretrain.policy_bc_batch_size",
+                self.policy_bc_batch_size,
+            )
 
 
 @dataclass
@@ -155,8 +171,11 @@ class BilinearSRConfig:
     sample_eval_interval: int = 50
     """Run sampling check every N SR updates (only when SR supports sampling)."""
 
-    detach_features_for_policy: bool = True
-    """Detach representation features before feeding to policy (no grad to SR)."""
+    detach_features_for_policy: bool = False
+    """Detach the final policy representation before feeding it to the policy MLP."""
+
+    policy_include_raw_state: bool = False
+    """Append raw SR state to F(s)z before the policy MLP."""
 
     ema_tau: float = 0.01
     """EMA update rate for the policy target state_net. Lower = slower tracking."""
@@ -257,7 +276,8 @@ class BilinearPolicyHead(GaussianPolicyHead):
         log_std_min: float = -20.0,
         log_std_max: float = 2.0,
         clip_log_std: bool = False,
-        detach_features: bool = True,
+        detach_features: bool = False,
+        include_raw_state: bool = False,
         device: str | torch.device = "cpu",
     ) -> None:
         base_mlp = MLP(
@@ -282,6 +302,7 @@ class BilinearPolicyHead(GaussianPolicyHead):
         # Detach prevents PPO gradients flowing into the representation.
         self.bilinear_rep = bilinear_rep
         self.detach_features = detach_features
+        self.include_raw_state = bool(include_raw_state)
         self.num_command_inputs = int(num_command_inputs)
         if self.num_command_inputs < 0:
             msg = "num_command_inputs must be >= 0."
@@ -334,9 +355,13 @@ class BilinearPolicyHead(GaussianPolicyHead):
             else:
                 assert self.command_projector is not None
                 z = self.command_projector(command)
-        rep = self.bilinear_rep.compute_policy_representation(state, z)
-        # if self.detach_features:
-        #     rep = rep.detach()
+        rep = self.bilinear_rep.compute_policy_representation(
+            state,
+            z,
+            include_raw_state=self.include_raw_state,
+        )
+        if self.detach_features:
+            rep = rep.detach()
         # Delegate to GaussianPolicyHead: base MLP + log_std_module
         loc = self.base(rep)
         scale = self.log_std_module(loc)
@@ -486,6 +511,58 @@ class IPMDBilinear(IPMD):
             )
             raise ValueError(msg)
         offline_cfg.validate()
+        self._preflight_offline_pretrain_batch()
+
+    def _preflight_offline_pretrain_batch(self) -> None:
+        offline_cfg = self.config.bilinear.offline_pretrain
+        preflight_batch_size = min(int(offline_cfg.batch_size), 8)
+        expert_batch = self._next_expert_batch(
+            batch_size=preflight_batch_size,
+            required_keys=self._offline_pretrain_required_keys(),
+        )
+        transitions = self._sr_transition_batch_from_td(
+            expert_batch,
+            action_key="expert_action",
+        )
+
+        obs = cast(Tensor, transitions.get("obs"))
+        action = cast(Tensor, transitions.get("action"))
+        next_obs = cast(Tensor, transitions.get(("next", "obs")))
+        self._validate_offline_pretrain_tensor_shape(
+            "obs",
+            obs,
+            batch_size=preflight_batch_size,
+            feature_dim=int(self.bilinear_rep.obs_dim),
+        )
+        self._validate_offline_pretrain_tensor_shape(
+            "action",
+            action,
+            batch_size=preflight_batch_size,
+            feature_dim=int(self.bilinear_rep.action_dim),
+        )
+        self._validate_offline_pretrain_tensor_shape(
+            "next_obs",
+            next_obs,
+            batch_size=preflight_batch_size,
+            feature_dim=int(self.bilinear_rep.next_obs_dim),
+        )
+
+    @staticmethod
+    def _validate_offline_pretrain_tensor_shape(
+        name: str,
+        tensor: Tensor,
+        *,
+        batch_size: int,
+        feature_dim: int,
+    ) -> None:
+        expected = (int(batch_size), int(feature_dim))
+        actual = tuple(tensor.shape)
+        if actual != expected:
+            msg = (
+                "Offline bilinear pretrain expert batch shape mismatch for "
+                f"{name}: expected {expected}, got {actual}."
+            )
+            raise ValueError(msg)
 
     def _bilinear_policy_command_keys(self) -> list[ObsKey]:
         bilinear_state_keys = set(self._bilinear_obs_keys)
@@ -536,6 +613,7 @@ class IPMDBilinear(IPMD):
                 log_std_max=self.config.ppo.log_std_max,
                 clip_log_std=self.config.ppo.clip_log_std,
                 detach_features=self.config.bilinear.detach_features_for_policy,
+                include_raw_state=self.config.bilinear.policy_include_raw_state,
                 device=self.device,
             )
             policy_in_keys = command_keys + list(self._bilinear_obs_keys)
@@ -600,6 +678,20 @@ class IPMDBilinear(IPMD):
         required.append("expert_action")
         return dedupe_keys(required)
 
+    def _offline_policy_bc_required_keys(self) -> list[BatchKey]:
+        required: list[BatchKey] = ["expert_action"]
+        required.extend(self._policy_obs_keys_without_latent)
+        if self._use_latent_command:
+            assert self._latent_learner is not None
+            required.extend(self._latent_learner.required_expert_batch_keys())
+        return dedupe_keys(required)
+
+    def _offline_pretrain_required_keys(self) -> list[BatchKey]:
+        required = self._offline_sr_required_keys()
+        if self.config.bilinear.offline_pretrain.policy_bc_updates > 0:
+            required.extend(self._offline_policy_bc_required_keys())
+        return dedupe_keys(required)
+
     def _sr_loss_from_batch(self, batch: TensorDict) -> tuple[dict[str, float], Tensor]:
         batch = batch.to(self.device)
         obs = cast(Tensor, batch.get("obs"))
@@ -662,12 +754,113 @@ class IPMDBilinear(IPMD):
             "sample/recon_l1": l1.item(),
         }
 
+    def _offline_policy_bc_step(self, expert_batch: TensorDict) -> dict[str, float]:
+        expert_batch = expert_batch.to(self.device)
+        expert_action = cast(Tensor, expert_batch.get("expert_action"))
+        expert_obs_td = expert_batch.clone(False)
+        if self._use_latent_command and self._latent_key not in expert_obs_td.keys(True):
+            expert_latents = self._expert_latents_from_td(
+                expert_batch,
+                detach=True,
+            ).reshape(*expert_batch.batch_size, self._latent_dim)
+            expert_obs_td.set(self._latent_key, expert_latents)
+        expert_obs_td = expert_obs_td.select(*self._policy_operator.in_keys)
+
+        self.optim.zero_grad(set_to_none=True)
+        dist = self._policy_operator.get_dist(expert_obs_td)
+        log_prob = dist.log_prob(expert_action)
+        log_prob = self._reduce_log_prob(log_prob, expert_action)
+        bc_nll = -log_prob.mean()
+        bc_nll.backward()
+        grad_norm = torch.nn.utils.clip_grad_norm_(
+            self._grad_clip_params,
+            self._max_grad_norm,
+        )
+        self.optim.step()
+
+        with torch.no_grad():
+            metrics = {
+                "bc_nll": bc_nll.item(),
+                "bc_log_prob_mean": log_prob.mean().item(),
+                "bc_expert_action_abs_mean": expert_action.abs().mean().item(),
+                "bc_actor_grad_norm": float(grad_norm),
+            }
+            scale = getattr(dist, "scale", None)
+            if isinstance(scale, Tensor):
+                metrics["bc_policy_scale_mean"] = scale.mean().item()
+        return metrics
+
+    def _offline_pretrain_policy_bc(self) -> None:
+        offline_cfg = self.config.bilinear.offline_pretrain
+        if offline_cfg.policy_bc_updates <= 0:
+            return
+
+        required_keys = self._offline_policy_bc_required_keys()
+        total_updates = int(offline_cfg.policy_bc_updates)
+        batch_size = int(offline_cfg.policy_bc_batch_size)
+        start_time = time.perf_counter()
+        self.actor_critic.train()
+        self.log.info(
+            "offline_policy_bc start | updates=%d | batch_size=%d | log_interval=%d",
+            total_updates,
+            batch_size,
+            int(offline_cfg.log_interval),
+        )
+        for update_idx in range(1, total_updates + 1):
+            expert_batch = self._next_expert_batch(
+                batch_size=batch_size,
+                required_keys=required_keys,
+            )
+            bc_metrics = self._offline_policy_bc_step(expert_batch)
+
+            if update_idx % offline_cfg.log_interval == 0 or update_idx in {
+                1,
+                total_updates,
+            }:
+                log_metrics = {
+                    f"offline/policy_bc/{key}": value
+                    for key, value in bc_metrics.items()
+                }
+                self.log_metrics(
+                    log_metrics,
+                    step=update_idx,
+                    log_python=bool(self.config.logger.log_to_console),
+                )
+                elapsed = time.perf_counter() - start_time
+                updates_per_sec = update_idx / elapsed
+                remaining_updates = total_updates - update_idx
+                eta_seconds = remaining_updates / updates_per_sec
+                self.log.info(
+                    "offline_policy_bc progress | update=%d/%d | %.1f%% | "
+                    "elapsed=%.1fs | eta=%.1fs | updates_per_sec=%.3f",
+                    update_idx,
+                    total_updates,
+                    100.0 * update_idx / total_updates,
+                    elapsed,
+                    eta_seconds,
+                    updates_per_sec,
+                )
+
+        self.log.info(
+            "offline_policy_bc complete | updates=%d | elapsed=%.1fs",
+            total_updates,
+            time.perf_counter() - start_time,
+        )
+
     def _offline_pretrain_spectral_representation(self) -> None:
         offline_cfg = self.config.bilinear.offline_pretrain
         if not offline_cfg.enabled:
             return
 
-        required_keys = self._offline_sr_required_keys()
+        required_keys = self._offline_pretrain_required_keys()
+        total_updates = int(offline_cfg.num_updates)
+        start_time = time.perf_counter()
+        self.log.info(
+            "offline_pretrain start | updates=%d | batch_size=%d | log_interval=%d",
+            total_updates,
+            int(offline_cfg.batch_size),
+            int(offline_cfg.log_interval),
+        )
         for update_idx in range(1, offline_cfg.num_updates + 1):
             expert_batch = self._next_expert_batch(
                 batch_size=offline_cfg.batch_size,
@@ -691,8 +884,31 @@ class IPMDBilinear(IPMD):
                     step=update_idx,
                     log_python=bool(self.config.logger.log_to_console),
                 )
+                elapsed = time.perf_counter() - start_time
+                updates_per_sec = update_idx / elapsed
+                remaining_updates = total_updates - update_idx
+                eta_seconds = remaining_updates / updates_per_sec
+                self.log.info(
+                    "offline_pretrain progress | update=%d/%d | %.1f%% | "
+                    "elapsed=%.1fs | eta=%.1fs | updates_per_sec=%.3f | "
+                    "history=%d",
+                    update_idx,
+                    total_updates,
+                    100.0 * update_idx / total_updates,
+                    elapsed,
+                    eta_seconds,
+                    updates_per_sec,
+                    len(self._sr_history_buffer),
+                )
 
         self.bilinear_rep.update_ema(1.0)
+        self.log.info(
+            "offline_pretrain complete | updates=%d | elapsed=%.1fs | history=%d",
+            total_updates,
+            time.perf_counter() - start_time,
+            len(self._sr_history_buffer),
+        )
+        self._offline_pretrain_policy_bc()
 
     def train(self) -> None:  # type: ignore[override]
         """Run offline SR pretraining, then the normal online IPMD loop."""
@@ -728,20 +944,14 @@ class IPMDBilinear(IPMD):
         for k, v in sr_metrics.items():
             self._pending_sr_metrics.setdefault(k, []).append(v)
 
-        self._pending_sr_metrics.setdefault("z_l1_mean", []).append(
-            iteration.rollout.get(self._latent_key)
-            .reshape(-1, self._latent_dim)
-            .abs()
-            .mean()
-            .item()
-        )
-        self._pending_sr_metrics.setdefault("z_l1_std", []).append(
-            iteration.rollout.get(self._latent_key)
-            .reshape(-1, self._latent_dim)
-            .std(dim=0)
-            .mean()
-            .item()
-        )
+        if self._use_latent_command:
+            latent = cast(Tensor, iteration.rollout.get(self._latent_key))
+            self._pending_sr_metrics.setdefault("z_l1_mean", []).append(
+                latent.reshape(-1, self._latent_dim).abs().mean().item()
+            )
+            self._pending_sr_metrics.setdefault("z_l1_std", []).append(
+                latent.reshape(-1, self._latent_dim).std(dim=0).mean().item()
+            )
         self._pending_sr_metrics.setdefault("history_buffer_size", []).append(
             float(len(self._sr_history_buffer))
         )

--- a/rlopt/agent/ipmd/module.py
+++ b/rlopt/agent/ipmd/module.py
@@ -27,7 +27,6 @@ from rlopt.agent.ipmd.network import (
     get_noise_schedule,
 )
 
-
 # ---------------------------------------------------------------------------
 # Empirical normalization
 # ---------------------------------------------------------------------------
@@ -154,19 +153,25 @@ class BilinearSR(ABC, nn.Module):
         if self.state_net_ema is None:
             return
         for p_ema, p_online in zip(
-            self.state_net_ema.parameters(), self.state_net.parameters()
+            self.state_net_ema.parameters(), self.state_net.parameters(), strict=True
         ):
             p_ema.data.lerp_(p_online.data, tau)
 
     # -- Policy / Q representation (shared) --
 
-    def compute_policy_representation(self, s: Tensor, z: Tensor = None) -> Tensor:
-        """F(s) z -> (B, embed_dim). Detached; uses EMA state_net when enabled."""
+    def compute_policy_representation(
+        self,
+        s: Tensor,
+        z: Tensor = None,
+        *,
+        include_raw_state: bool = True,
+    ) -> Tensor:
+        """F(s) z -> (B, embed_dim). Optionally append raw SR state."""
         F_s = self._F(s, use_ema=True).detach()
-        # return torch.einsum("bef,bf->be", F_s, z)
         component1 = torch.einsum("bef,bf->be", F_s, z)
-        component2 = s.detach()
-        return torch.concat([component1, component2], dim=-1)
+        if include_raw_state:
+            return torch.concat([component1, s.detach()], dim=-1)
+        return component1
 
     def compute_q_representation(self, s: Tensor, a: Tensor) -> Tensor:
         """Return phi(s, a) for Q-function use."""
@@ -198,17 +203,16 @@ class BilinearSR(ABC, nn.Module):
         preserve_history: bool = False,
     ) -> tuple[Tensor, dict]:
         """Generate s' given (s, a). Only supported by diffusion-based SR."""
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support generative sampling."
-        )
+        msg = f"{type(self).__name__} does not support generative sampling."
+        raise NotImplementedError(msg)
 
     @property
     def supports_sampling(self) -> bool:
         return False
 
-    def update_obs_norm(self, next_obs: Tensor) -> None:
+    def update_obs_norm(self, _next_obs: Tensor) -> None:
         """Update observation normalization statistics. No-op by default."""
-        pass
+        del _next_obs
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +325,7 @@ class DiffSRBilinear(BilinearSR):
         s: Tensor,
         a: Tensor,
         sp: Tensor,
-        r: Tensor,
+        _r: Tensor,
     ) -> tuple[dict[str, float], Tensor, Tensor]:
         x0 = self.obs_norm.normalize(sp)
         xt, t, eps = self.add_noise(x0)
@@ -490,7 +494,7 @@ class SpederBilinear(BilinearSR):
         s: Tensor,
         a: Tensor,
         sp: Tensor,
-        r: Tensor,
+        _r: Tensor,
     ) -> tuple[dict[str, float], Tensor, Tensor]:
         B = sp.shape[0]
         N = self.num_noises if self.use_noise_perturbation else 1
@@ -654,7 +658,7 @@ class CtrlSRBilinear(BilinearSR):
         s: Tensor,
         a: Tensor,
         sp: Tensor,
-        r: Tensor,
+        _r: Tensor,
     ) -> tuple[dict[str, float], Tensor, Tensor]:
         B = sp.shape[0]
         z_phi = self.forward_phi(s, a)  # (B, feature_dim)
@@ -732,7 +736,6 @@ def build_bilinear_sr(sr_type: str, **kwargs) -> BilinearSR:
     """
     cls = SR_REGISTRY.get(sr_type)
     if cls is None:
-        raise ValueError(
-            f"Unknown sr_type={sr_type!r}. Available: {list(SR_REGISTRY.keys())}"
-        )
+        msg = f"Unknown sr_type={sr_type!r}. Available: {list(SR_REGISTRY.keys())}"
+        raise ValueError(msg)
     return cls(**kwargs)

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -19,12 +19,14 @@ def _rlopt() -> SimpleNamespace:
         category=DeprecationWarning,
         append=False,
     )
-    from rlopt.agent import IPMD, IPMDRLOptConfig
+    from rlopt.agent import IPMD, IPMDBilinear, IPMDBilinearRLOptConfig, IPMDRLOptConfig
     from rlopt.config_base import NetworkConfig
     from rlopt.env_utils import make_parallel_env
 
     return SimpleNamespace(
         IPMD=IPMD,
+        IPMDBilinear=IPMDBilinear,
+        IPMDBilinearRLOptConfig=IPMDBilinearRLOptConfig,
         IPMDRLOptConfig=IPMDRLOptConfig,
         NetworkConfig=NetworkConfig,
         make_parallel_env=make_parallel_env,
@@ -115,6 +117,120 @@ def _make_env_reward_only_ipmd_agent():
     return rlopt.IPMD(env, cfg, logger=None), env
 
 
+def _make_bilinear_offline_cfg():
+    rlopt = _rlopt()
+    cfg = rlopt.IPMDBilinearRLOptConfig()
+    cfg.env.env_name = "Pendulum-v1"
+    cfg.env.device = "cpu"
+    cfg.device = "cpu"
+    cfg.collector.frames_per_batch = 4
+    cfg.collector.total_frames = 4
+    cfg.replay_buffer.size = 64
+    cfg.loss.mini_batch_size = 2
+    cfg.compile.compile = False
+    cfg.logger.backend = ""
+    cfg.policy.input_keys = ["observation"]
+    cfg.policy.num_cells = [16]
+    if cfg.value_function is not None:
+        cfg.value_function.input_keys = ["observation"]
+        cfg.value_function.num_cells = [16]
+    cfg.ipmd.use_latent_command = False
+    cfg.ipmd.reward_input_keys = ["observation"]
+    cfg.ipmd.reward_num_cells = (16,)
+    cfg.ipmd.reward_loss_coeff = 0.0
+    cfg.ipmd.reward_l2_coeff = 0.0
+    cfg.ipmd.reward_grad_penalty_coeff = 0.0
+    cfg.ipmd.bc_coef = 0.0
+    cfg.ipmd.diversity_bonus_coeff = 0.0
+    cfg.bilinear.obs_keys = ["observation"]
+    cfg.bilinear.next_obs_keys = ["observation"]
+    cfg.bilinear.feature_dim = 3
+    cfg.bilinear.embed_dim = 8
+    cfg.bilinear.f_hidden_dims = (16,)
+    cfg.bilinear.g_hidden_dims = (16,)
+    cfg.bilinear.mu_hidden_dims = (16,)
+    cfg.bilinear.sr_batch_size = 4
+    cfg.bilinear.history_buffer_size = 64
+    cfg.bilinear.num_noises = 2
+    cfg.bilinear.sample_eval_interval = 0
+    cfg.bilinear.offline_pretrain.enabled = True
+    cfg.bilinear.offline_pretrain.num_updates = 2
+    cfg.bilinear.offline_pretrain.batch_size = 8
+    cfg.bilinear.offline_pretrain.log_interval = 1
+    return cfg
+
+
+class _BilinearTestPolicyHead(torch.nn.Module):
+    def __init__(self, obs_dim: int, action_dim: int) -> None:
+        super().__init__()
+        self.loc = torch.nn.Linear(obs_dim, action_dim)
+        self.log_std = torch.nn.Parameter(torch.zeros(action_dim))
+
+    def forward(self, obs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        loc = self.loc(obs)
+        scale = self.log_std.exp().expand_as(loc)
+        return loc, scale
+
+
+def _make_bilinear_test_policy_head(env) -> _BilinearTestPolicyHead:
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    action_dim = env.action_spec.shape[-1]
+    return _BilinearTestPolicyHead(obs_dim, action_dim)
+
+
+def _make_bilinear_expert_batch(env, num_transitions: int = 32) -> TensorDict:
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    act_dim = env.action_spec.shape[-1]
+    return TensorDict(
+        {
+            "observation": torch.randn(num_transitions, obs_dim),
+            ("next", "observation"): torch.randn(num_transitions, obs_dim),
+            "expert_action": torch.randn(num_transitions, act_dim),
+        },
+        batch_size=[num_transitions],
+    )
+
+
+def test_bilinear_policy_head_splits_command_from_representation_state() -> None:
+    """Policy command keys should not be concatenated into the SR state input."""
+    _rlopt()
+    from rlopt.agent.ipmd.ipmd_bilinear import BilinearPolicyHead
+    from rlopt.agent.ipmd.module import build_bilinear_sr
+
+    bilinear_rep = build_bilinear_sr(
+        "diffsr",
+        obs_dim=5,
+        next_obs_dim=4,
+        action_dim=2,
+        feature_dim=3,
+        embed_dim=4,
+        f_hidden_dims=(8,),
+        g_hidden_dims=(8,),
+        mu_hidden_dims=(8,),
+        num_noises=2,
+        use_ema_for_policy=True,
+        device="cpu",
+    )
+    head = BilinearPolicyHead(
+        bilinear_rep=bilinear_rep,
+        num_cells=[8],
+        activation_fn="elu",
+        action_dim=2,
+        num_command_inputs=2,
+        command_dim=7,
+        device="cpu",
+    )
+
+    loc, scale = head(
+        torch.randn(6, 2),
+        torch.randn(6, 5),
+        torch.randn(6, 5),
+    )
+
+    assert loc.shape == (6, 2)
+    assert scale.shape == (6, 2)
+
+
 def test_ipmd_prepare_rollout_rewards_ignores_estimator_when_disabled():
     """Disabled estimated PPO rewards should leave env rewards untouched."""
     agent, env = _make_env_reward_only_ipmd_agent()
@@ -153,6 +269,132 @@ def test_ipmd_disabled_reward_update_disables_expert_minibatch_path():
     """Pure-PPO IPMD configs should skip the expert minibatch path entirely."""
     agent, _ = _make_env_reward_only_ipmd_agent()
     assert agent._expert_minibatch_update_enabled is False
+
+
+def test_ipmd_bilinear_offline_pretrain_requires_expert_sampler() -> None:
+    """Offline SR pretraining should fail at construction without a sampler."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    env = rlopt.make_parallel_env(cfg)
+
+    with pytest.raises(ValueError, match="sample_expert_batch"):
+        rlopt.IPMDBilinear(
+            env,
+            cfg,
+            policy_net=_make_bilinear_test_policy_head(env),
+            logger=None,
+        )
+
+
+def test_ipmd_bilinear_offline_pretrain_validates_config() -> None:
+    """Offline SR pretraining validates positive update, batch, and log values."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    cfg.bilinear.offline_pretrain.batch_size = 0
+    env = rlopt.make_parallel_env(cfg)
+    env.sample_expert_batch = lambda batch_size, _required_keys: TensorDict(
+        {},
+        batch_size=[batch_size],
+    )
+
+    with pytest.raises(ValueError, match="offline_pretrain.batch_size"):
+        rlopt.IPMDBilinear(
+            env,
+            cfg,
+            policy_net=_make_bilinear_test_policy_head(env),
+            logger=None,
+        )
+
+
+def test_ipmd_bilinear_offline_pretrain_uses_expert_action_and_next_obs() -> None:
+    """Offline SR pretraining should request explicit next-state keys and expert actions."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    env = rlopt.make_parallel_env(cfg)
+    expert_data = _make_bilinear_expert_batch(env)
+    requested: list[list[str | tuple[str, ...]]] = []
+
+    def _sample_expert_batch(batch_size: int, required_keys):
+        requested.append(list(required_keys))
+        return expert_data[:batch_size].select(*required_keys).clone()
+
+    env.sample_expert_batch = _sample_expert_batch
+    agent = rlopt.IPMDBilinear(
+        env,
+        cfg,
+        policy_net=_make_bilinear_test_policy_head(env),
+        logger=None,
+    )
+
+    sr_before = {
+        name: param.detach().clone()
+        for name, param in agent.bilinear_rep.named_parameters()
+    }
+    non_sr_actor_before = {
+        name: param.detach().clone()
+        for name, param in agent.actor_critic.named_parameters()
+        if "bilinear_rep" not in name
+    }
+    reward_before = {
+        name: param.detach().clone()
+        for name, param in agent.reward_estimator.named_parameters()
+    }
+
+    agent._offline_pretrain_spectral_representation()
+
+    assert requested
+    assert requested[0] == ["observation", ("next", "observation"), "expert_action"]
+    assert len(agent._sr_history_buffer) == (
+        cfg.bilinear.offline_pretrain.num_updates
+        * cfg.bilinear.offline_pretrain.batch_size
+    )
+    assert agent.bilinear_rep.obs_norm.count.item() == len(agent._sr_history_buffer)
+    assert any(
+        not torch.allclose(param, sr_before[name])
+        for name, param in agent.bilinear_rep.named_parameters()
+    )
+    for name, param in agent.actor_critic.named_parameters():
+        if "bilinear_rep" not in name:
+            assert torch.allclose(param, non_sr_actor_before[name])
+    for name, param in agent.reward_estimator.named_parameters():
+        assert torch.allclose(param, reward_before[name])
+    assert agent.bilinear_rep.state_net_ema is not None
+    for online, ema in zip(
+        agent.bilinear_rep.state_net.parameters(),
+        agent.bilinear_rep.state_net_ema.parameters(),
+        strict=True,
+    ):
+        assert torch.allclose(online, ema)
+
+
+def test_ipmd_bilinear_offline_missing_required_keys_fails_before_update() -> None:
+    """A malformed expert batch should fail before any offline SR optimizer step."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    env = rlopt.make_parallel_env(cfg)
+    expert_data = _make_bilinear_expert_batch(env)
+
+    def _sample_expert_batch(batch_size: int, required_keys):
+        del required_keys
+        return expert_data[:batch_size].select("observation").clone()
+
+    env.sample_expert_batch = _sample_expert_batch
+    agent = rlopt.IPMDBilinear(
+        env,
+        cfg,
+        policy_net=_make_bilinear_test_policy_head(env),
+        logger=None,
+    )
+    sr_before = {
+        name: param.detach().clone()
+        for name, param in agent.bilinear_rep.named_parameters()
+    }
+
+    with pytest.raises(RuntimeError, match="missing required keys"):
+        agent._offline_pretrain_spectral_representation()
+
+    for name, param in agent.bilinear_rep.named_parameters():
+        assert torch.allclose(param, sr_before[name])
 
 
 def test_ipmd_prepare_rollout_rewards_honors_estimated_reward_gate():

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from tensordict import TensorDict
+from torchrl.data import Unbounded
 
 
 @lru_cache(maxsize=1)
@@ -185,7 +186,7 @@ def _make_bilinear_expert_batch(env, num_transitions: int = 32) -> TensorDict:
         {
             "observation": torch.randn(num_transitions, obs_dim),
             ("next", "observation"): torch.randn(num_transitions, obs_dim),
-            "expert_action": torch.randn(num_transitions, act_dim),
+            "expert_action": torch.tanh(torch.randn(num_transitions, act_dim)),
         },
         batch_size=[num_transitions],
     )
@@ -229,6 +230,27 @@ def test_bilinear_policy_head_splits_command_from_representation_state() -> None
 
     assert loc.shape == (6, 2)
     assert scale.shape == (6, 2)
+    assert head.base[0].in_features == 4
+
+    raw_state_head = BilinearPolicyHead(
+        bilinear_rep=bilinear_rep,
+        num_cells=[8],
+        activation_fn="elu",
+        action_dim=2,
+        num_command_inputs=2,
+        command_dim=7,
+        include_raw_state=True,
+        device="cpu",
+    )
+    loc, scale = raw_state_head(
+        torch.randn(6, 2),
+        torch.randn(6, 5),
+        torch.randn(6, 5),
+    )
+
+    assert loc.shape == (6, 2)
+    assert scale.shape == (6, 2)
+    assert raw_state_head.base[0].in_features == 9
 
 
 def test_ipmd_prepare_rollout_rewards_ignores_estimator_when_disabled():
@@ -306,6 +328,20 @@ def test_ipmd_bilinear_offline_pretrain_validates_config() -> None:
         )
 
 
+def test_ipmd_bilinear_offline_pretrain_constructs_default_policy_head() -> None:
+    """Offline preflight should work with the production bilinear policy head."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    env = rlopt.make_parallel_env(cfg)
+    expert_data = _make_bilinear_expert_batch(env)
+    env.sample_expert_batch = _make_test_expert_sampler(expert_data)
+
+    agent = rlopt.IPMDBilinear(env, cfg, logger=None)
+
+    assert agent.policy is not None
+    assert len(agent._sr_history_buffer) == 0
+
+
 def test_ipmd_bilinear_offline_pretrain_uses_expert_action_and_next_obs() -> None:
     """Offline SR pretraining should request explicit next-state keys and expert actions."""
     rlopt = _rlopt()
@@ -367,8 +403,82 @@ def test_ipmd_bilinear_offline_pretrain_uses_expert_action_and_next_obs() -> Non
         assert torch.allclose(online, ema)
 
 
-def test_ipmd_bilinear_offline_missing_required_keys_fails_before_update() -> None:
-    """A malformed expert batch should fail before any offline SR optimizer step."""
+def test_ipmd_bilinear_offline_policy_bc_updates_actor_after_sr_pretrain() -> None:
+    """Offline policy BC should update the same feature-only actor used online."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    cfg.bilinear.policy_include_raw_state = False
+    cfg.bilinear.offline_pretrain.policy_bc_updates = 2
+    cfg.bilinear.offline_pretrain.policy_bc_batch_size = 8
+    env = rlopt.make_parallel_env(cfg)
+    expert_data = _make_bilinear_expert_batch(env)
+    requested: list[list[str | tuple[str, ...]]] = []
+
+    def _sample_expert_batch(batch_size: int, required_keys):
+        requested.append(list(required_keys))
+        return expert_data[:batch_size].select(*required_keys).clone()
+
+    env.sample_expert_batch = _sample_expert_batch
+    agent = rlopt.IPMDBilinear(env, cfg, logger=None)
+    non_sr_actor_before = {
+        name: param.detach().clone()
+        for name, param in agent.actor_critic.named_parameters()
+        if "bilinear_rep" not in name
+    }
+
+    agent._offline_pretrain_spectral_representation()
+
+    assert requested
+    assert ["observation", ("next", "observation"), "expert_action"] in requested
+    assert any(
+        not torch.allclose(param, non_sr_actor_before[name])
+        for name, param in agent.actor_critic.named_parameters()
+        if "bilinear_rep" not in name
+    )
+
+
+def test_ipmd_bilinear_offline_pretrain_handles_distinct_next_obs_dim() -> None:
+    """Offline SR pretraining should support s and s' with different feature widths."""
+    rlopt = _rlopt()
+    cfg = _make_bilinear_offline_cfg()
+    cfg.bilinear.next_obs_keys = ["next_observation"]
+    cfg.bilinear.sample_eval_interval = 1
+    env = rlopt.make_parallel_env(cfg)
+    next_obs_dim = 2
+    env.output_spec.unlock_()
+    env.output_spec["full_observation_spec", "next_observation"] = Unbounded(
+        shape=(*env.batch_size, next_obs_dim),
+        device="cpu",
+    )
+    env.output_spec.lock_()
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    act_dim = env.action_spec.shape[-1]
+    expert_data = TensorDict(
+        {
+            "observation": torch.randn(32, obs_dim),
+            ("next", "next_observation"): torch.randn(32, next_obs_dim),
+            "expert_action": torch.randn(32, act_dim),
+        },
+        batch_size=[32],
+    )
+    env.sample_expert_batch = _make_test_expert_sampler(expert_data)
+    agent = rlopt.IPMDBilinear(
+        env,
+        cfg,
+        policy_net=_make_bilinear_test_policy_head(env),
+        logger=None,
+    )
+
+    agent._offline_pretrain_spectral_representation()
+
+    assert len(agent._sr_history_buffer) == (
+        cfg.bilinear.offline_pretrain.num_updates
+        * cfg.bilinear.offline_pretrain.batch_size
+    )
+
+
+def test_ipmd_bilinear_offline_missing_required_keys_fails_at_construction() -> None:
+    """A malformed expert batch should fail during offline pretrain preflight."""
     rlopt = _rlopt()
     cfg = _make_bilinear_offline_cfg()
     env = rlopt.make_parallel_env(cfg)
@@ -379,22 +489,14 @@ def test_ipmd_bilinear_offline_missing_required_keys_fails_before_update() -> No
         return expert_data[:batch_size].select("observation").clone()
 
     env.sample_expert_batch = _sample_expert_batch
-    agent = rlopt.IPMDBilinear(
-        env,
-        cfg,
-        policy_net=_make_bilinear_test_policy_head(env),
-        logger=None,
-    )
-    sr_before = {
-        name: param.detach().clone()
-        for name, param in agent.bilinear_rep.named_parameters()
-    }
 
     with pytest.raises(RuntimeError, match="missing required keys"):
-        agent._offline_pretrain_spectral_representation()
-
-    for name, param in agent.bilinear_rep.named_parameters():
-        assert torch.allclose(param, sr_before[name])
+        rlopt.IPMDBilinear(
+            env,
+            cfg,
+            policy_net=_make_bilinear_test_policy_head(env),
+            logger=None,
+        )
 
 
 def test_ipmd_prepare_rollout_rewards_honors_estimated_reward_gate():


### PR DESCRIPTION
## Summary
- Restore the bilinear policy default to feature-only input: F(s)z, without concatenating the raw state.
- Keep feature values detached for the policy path while allowing the posterior/latent command path to receive policy gradients.
- Add and update focused coverage for bilinear policy representation, command feature width, and offline SR pretraining behavior.

## Validation
- Focused RLOpt bilinear tests passed: 8 passed.
- 1024-env Dance102 smoke matched the intended latent v0 policy input shape.
- Skynet 4096-env Dance102 job 3121342 completed successfully.