### PR TITLE
[codex] Improve bilinear latent pretraining controls

### DIFF
--- a/rlopt/agent/imitation/latent_learning.py
+++ b/rlopt/agent/imitation/latent_learning.py
@@ -260,6 +260,8 @@ class PatchAutoencoderLatentLearner(BaseLatentLearner):
         self.encoder: LatentEncoder | None = None
         self.decoder: LatentDecoder | None = None
         self.optimizer: torch.optim.Optimizer | None = None
+        self._collector_latents: Tensor | None = None
+        self._collector_steps: Tensor | None = None
 
     def _config(self):
         assert self.agent is not None
@@ -345,6 +347,91 @@ class PatchAutoencoderLatentLearner(BaseLatentLearner):
             with torch.no_grad():
                 return self.encoder(patch_features)
         return self.encoder(patch_features)
+
+    def _renew_collector_latents(
+        self,
+        td: TensorDict,
+        renew_mask: Tensor,
+    ) -> None:
+        assert self.agent is not None
+        latents = self.infer_batch_latents(
+            td,
+            detach=True,
+            context="collector posterior latent",
+        )
+        if latents is None:
+            msg = "patch_autoencoder failed to infer collector latents."
+            raise RuntimeError(msg)
+        latents = latents.to(self.agent.device).reshape(-1, self.agent._latent_dim)
+        if self._collector_latents is None or self._collector_latents.shape != latents.shape:
+            self._collector_latents = latents.clone()
+        else:
+            self._collector_latents[renew_mask] = latents[renew_mask]
+
+    def infer_collector_latents(self, td: TensorDict) -> Tensor:
+        """Infer posterior latents and optionally hold them for multiple env steps."""
+        assert self.agent is not None
+        cfg = self._config()
+        device = self.agent.device
+        command_dim = int(self.agent._latent_dim)
+        period = max(1, int(cfg.posterior_command_period))
+        if period <= 1:
+            latents = self.infer_batch_latents(
+                td,
+                detach=True,
+                context="collector posterior latent",
+            )
+            if latents is None:
+                return torch.empty(0, command_dim, device=device)
+            return latents.to(device=device).reshape(-1, command_dim)
+
+        batch_size = int(td.numel())
+        if batch_size <= 0:
+            return torch.empty(0, command_dim, device=device)
+
+        if (
+            self._collector_latents is None
+            or self._collector_latents.shape[0] != batch_size
+            or self._collector_latents.shape[1] != command_dim
+            or self._collector_latents.device != device
+        ):
+            self._collector_latents = torch.zeros(batch_size, command_dim, device=device)
+            self._collector_steps = torch.zeros(
+                batch_size, device=device, dtype=torch.long
+            )
+
+        assert self._collector_steps is not None
+        done_mask = self._build_done_mask(td, batch_size=batch_size, device=device)
+        renew_mask = done_mask | (self._collector_steps <= 0)
+        if bool(renew_mask.any()):
+            self._renew_collector_latents(td, renew_mask)
+            self._collector_steps[renew_mask] = period
+        command = self._collector_latents
+        self._collector_steps -= 1
+        return command
+
+    @staticmethod
+    def _build_done_mask(
+        td: TensorDict, *, batch_size: int, device: torch.device
+    ) -> Tensor:
+        mask = torch.zeros(batch_size, device=device, dtype=torch.bool)
+        candidates: list[BatchKey] = [
+            cast(BatchKey, "done"),
+            cast(BatchKey, "terminated"),
+            cast(BatchKey, "truncated"),
+            cast(BatchKey, "is_init"),
+            cast(BatchKey, ("next", "done")),
+            cast(BatchKey, ("next", "terminated")),
+            cast(BatchKey, ("next", "truncated")),
+        ]
+        keys = td.keys(True)
+        for key in candidates:
+            if key not in keys:
+                continue
+            value = cast(Tensor, td.get(key)).reshape(-1).to(device=device).bool()
+            if value.numel() == batch_size:
+                mask |= value
+        return mask
 
     def reconstruct_batch_features(
         self,
@@ -1471,6 +1558,23 @@ class PatchVQVAELatentLearner(BaseLatentLearner):
             agent._obs_feature_dims[key] for key in self._posterior_input_keys()
         )
         self._ensure_modules(int(input_dim))
+
+    def joint_parameters(self) -> list[nn.Parameter]:
+        assert self.agent is not None
+        cfg = self._config()
+        if (
+            not bool(cfg.train_posterior_through_policy)
+            or bool(cfg.freeze_encoder)
+            or self.encoder is None
+        ):
+            return []
+
+        params: list[nn.Parameter] = list(self.encoder.parameters())
+        if self.code_to_latent is not None:
+            params += list(self.code_to_latent.parameters())
+        if self.gumbel is not None:
+            params += list(self.gumbel.parameters())
+        return params
 
     # ----- core encode + quantize -----------------------------------------------
     def _current_tau(self) -> float:

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -60,6 +60,7 @@ from rlopt.config_utils import (
     obs_key_feature_dim,
     obs_key_feature_ndim,
 )
+from rlopt.expert import build_offline_expert_sampler
 from rlopt.type_aliases import OptimizerClass
 from rlopt.utils import get_activation_class, log_info
 
@@ -763,6 +764,9 @@ class IPMD(PPO):
         self._expert_batch_sampler: (
             Callable[[int, list[BatchKey]], TensorDict | None] | None
         ) = None
+        self._offline_expert_batch_sampler: (
+            Callable[[int, list[BatchKey]], TensorDict | None] | None
+        ) = None
 
         self._latent_learner: BaseLatentLearner | None = None
 
@@ -837,11 +841,85 @@ class IPMD(PPO):
             **kwargs,
         )
         self._auto_attach_env_expert_sampler()
+        self._auto_attach_offline_expert_sampler()
         self._validate_expert_transition_alignment()
         self._refresh_grad_clip_params()
         self._reward_grad_clip_params = list(self.reward_estimator.parameters())
         self._policy_operator = self.actor_critic.get_policy_operator()
         self._bc_debug_anomaly_prints = 0
+
+    def _auto_attach_offline_expert_sampler(self) -> None:
+        """Attach a configured offline dataset sampler after env construction."""
+        sampler = build_offline_expert_sampler(self.config, self.env)
+        if sampler is None:
+            return
+        self._offline_expert_batch_sampler = sampler
+        offline_cfg = self.config.offline_dataset
+        self.log.info(
+            "Using offline dataset sampler: source=%s repo_id=%s mapper=%s",
+            offline_cfg.source,
+            offline_cfg.repo_id,
+            offline_cfg.mapper,
+        )
+        if not bool(offline_cfg.replace_expert_sampler):
+            return
+
+        self._expert_batch_sampler = sampler
+        self._expert_sampler_source_name = "offline_dataset"
+        required_keys = (
+            self._expert_required_keys() if self._expert_minibatch_update_enabled else []
+        )
+        if required_keys:
+            preflight_batch_size = min(
+                int(
+                    self.config.ipmd.expert_batch_size
+                    or self.config.loss.mini_batch_size
+                ),
+                8,
+            )
+            _ = sampler(preflight_batch_size, required_keys)
+
+    def _next_offline_expert_batch(
+        self,
+        batch_size: int | None = None,
+        required_keys: list[BatchKey] | None = None,
+    ) -> TensorDict:
+        if self._offline_expert_batch_sampler is None:
+            return self._next_expert_batch(
+                batch_size=batch_size,
+                required_keys=required_keys,
+            )
+        assert isinstance(self.config, IPMDRLOptConfig)
+        effective_batch_size = int(
+            batch_size
+            or self.config.ipmd.expert_batch_size
+            or self.config.loss.mini_batch_size
+        )
+        required_keys = (
+            self._expert_required_keys() if required_keys is None else required_keys
+        )
+        expert_batch = self._offline_expert_batch_sampler(
+            effective_batch_size,
+            required_keys,
+        )
+        if expert_batch is None:
+            msg = "Offline expert sampler returned None."
+            raise RuntimeError(msg)
+        available_keys = set(expert_batch.keys(True))
+        missing_keys = [key for key in required_keys if key not in available_keys]
+        if missing_keys:
+            msg = (
+                "Offline expert sampler batch is missing required keys: "
+                f"{missing_keys!r}."
+            )
+            raise RuntimeError(msg)
+        if expert_batch.numel() != effective_batch_size:
+            msg = (
+                "Offline expert sampler must return exactly the requested batch size, got "
+                f"{expert_batch.numel()} for request {effective_batch_size}."
+            )
+            raise RuntimeError(msg)
+        return expert_batch.to(self.device)
 
     def _require_latent_command_controller(self) -> LatentCommandController:
         controller = self._latent_command_controller
@@ -996,6 +1074,8 @@ class IPMD(PPO):
             for key in self._expert_required_keys()
         )
         if not requires_next_obs or self._expert_batch_sampler is None:
+            return
+        if getattr(self, "_expert_sampler_source_name", None) == "offline_dataset":
             return
 
         aligned_next = getattr(self.env, "_reference_has_aligned_next", None)

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -210,6 +210,14 @@ class IPMDLatentLearningConfig:
     are bypassed in that posterior path.
     """
 
+    posterior_command_period: int = 1
+    """Env steps a continuous posterior command is held during rollout.
+
+    Used by continuous posterior learners such as ``patch_autoencoder``.
+    A value of 1 preserves the original behavior and refreshes the posterior
+    command every env step.
+    """
+
     latent_dropout_to_random_code_prob: float = 0.0
     """Reserved for random-code substitution during PPO updates."""
 
@@ -233,6 +241,10 @@ class IPMDLatentLearningConfig:
 
         self.code_period = require_positive_int(
             "ipmd.latent_learning.code_period", self.code_period
+        )
+        self.posterior_command_period = require_positive_int(
+            "ipmd.latent_learning.posterior_command_period",
+            self.posterior_command_period,
         )
         if self.code_latent_dim is not None:
             self.code_latent_dim = require_positive_int(
@@ -2102,6 +2114,10 @@ class IPMD(PPO):
             data_to_save["reward_optimizer_state_dict"] = self.reward_optim.state_dict()
         if self.lr_scheduler is not None:
             data_to_save["lr_scheduler_state_dict"] = self.lr_scheduler.state_dict()
+        if self._latent_learner is not None:
+            data_to_save["latent_learner_state_dict"] = (
+                self._latent_learner.checkpoint_state_dict()
+            )
         if (
             hasattr(self.env, "is_closed")
             and not self.env.is_closed
@@ -2135,6 +2151,10 @@ class IPMD(PPO):
         if self.config.feature_extractor and "feature_extractor_state_dict" in data:
             self.feature_extractor.load_state_dict(
                 data["feature_extractor_state_dict"]  # type: ignore[arg-type]
+            )
+        if self._latent_learner is not None and "latent_learner_state_dict" in data:
+            self._latent_learner.load_checkpoint_state_dict(
+                data["latent_learner_state_dict"]
             )
         if hasattr(self.env, "normalize_obs") and "vec_norm_msg" in data:
             self.env.load_state_dict(data["vec_norm_msg"])  # type: ignore[arg-type]

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -397,13 +397,17 @@ class IPMDBilinear(IPMD):
         self.config.bilinear.validate()
         self.env = env
         self._provided_bilinear_policy_net = policy_net
+        offline_dataset_enabled = bool(
+            getattr(self.config.offline_dataset, "enabled", False)
+        )
         if (
             self.config.bilinear.offline_pretrain.enabled
+            and not offline_dataset_enabled
             and self._discover_env_method(env, "sample_expert_batch") is None
         ):
             msg = (
                 "bilinear.offline_pretrain.enabled=True requires "
-                "env.sample_expert_batch(...)."
+                "env.sample_expert_batch(...) or offline_dataset.enabled=True."
             )
             raise ValueError(msg)
 
@@ -504,10 +508,13 @@ class IPMDBilinear(IPMD):
         offline_cfg = self.config.bilinear.offline_pretrain
         if not offline_cfg.enabled:
             return
-        if self._expert_batch_sampler is None:
+        if (
+            self._offline_expert_batch_sampler is None
+            and self._expert_batch_sampler is None
+        ):
             msg = (
                 "bilinear.offline_pretrain.enabled=True requires "
-                "env.sample_expert_batch(...)."
+                "env.sample_expert_batch(...) or offline_dataset.enabled=True."
             )
             raise ValueError(msg)
         offline_cfg.validate()
@@ -516,7 +523,7 @@ class IPMDBilinear(IPMD):
     def _preflight_offline_pretrain_batch(self) -> None:
         offline_cfg = self.config.bilinear.offline_pretrain
         preflight_batch_size = min(int(offline_cfg.batch_size), 8)
-        expert_batch = self._next_expert_batch(
+        expert_batch = self._next_offline_expert_batch(
             batch_size=preflight_batch_size,
             required_keys=self._offline_pretrain_required_keys(),
         )
@@ -758,7 +765,9 @@ class IPMDBilinear(IPMD):
         expert_batch = expert_batch.to(self.device)
         expert_action = cast(Tensor, expert_batch.get("expert_action"))
         expert_obs_td = expert_batch.clone(False)
-        if self._use_latent_command and self._latent_key not in expert_obs_td.keys(True):
+        if self._use_latent_command and self._latent_key not in expert_obs_td.keys(
+            True
+        ):
             expert_latents = self._expert_latents_from_td(
                 expert_batch,
                 detach=True,
@@ -807,7 +816,7 @@ class IPMDBilinear(IPMD):
             int(offline_cfg.log_interval),
         )
         for update_idx in range(1, total_updates + 1):
-            expert_batch = self._next_expert_batch(
+            expert_batch = self._next_offline_expert_batch(
                 batch_size=batch_size,
                 required_keys=required_keys,
             )
@@ -862,7 +871,7 @@ class IPMDBilinear(IPMD):
             int(offline_cfg.log_interval),
         )
         for update_idx in range(1, offline_cfg.num_updates + 1):
-            expert_batch = self._next_expert_batch(
+            expert_batch = self._next_offline_expert_batch(
                 batch_size=offline_cfg.batch_size,
                 required_keys=required_keys,
             )

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -96,22 +96,29 @@ class BilinearOfflinePretrainConfig:
     policy_bc_batch_size: int = 8192
     """Expert action batch size for offline policy BC."""
 
+    policy_bc_train_latent: bool = False
+    """Allow offline policy BC gradients to update inferred latent-command modules."""
+
+    def requires_offline_data(self) -> bool:
+        return bool(self.enabled or int(self.policy_bc_updates) > 0)
+
     def validate(self) -> None:
-        if not self.enabled:
-            return
-        self.num_updates = require_positive_int(
-            "bilinear.offline_pretrain.num_updates", self.num_updates
-        )
-        self.batch_size = require_positive_int(
-            "bilinear.offline_pretrain.batch_size", self.batch_size
-        )
-        self.log_interval = require_positive_int(
-            "bilinear.offline_pretrain.log_interval", self.log_interval
-        )
         self.policy_bc_updates = _require_non_negative_int(
             "bilinear.offline_pretrain.policy_bc_updates",
             self.policy_bc_updates,
         )
+        if not self.requires_offline_data():
+            return
+        self.log_interval = require_positive_int(
+            "bilinear.offline_pretrain.log_interval", self.log_interval
+        )
+        if self.enabled:
+            self.num_updates = require_positive_int(
+                "bilinear.offline_pretrain.num_updates", self.num_updates
+            )
+            self.batch_size = require_positive_int(
+                "bilinear.offline_pretrain.batch_size", self.batch_size
+            )
         if self.policy_bc_updates > 0:
             self.policy_bc_batch_size = require_positive_int(
                 "bilinear.offline_pretrain.policy_bc_batch_size",
@@ -360,8 +367,8 @@ class BilinearPolicyHead(GaussianPolicyHead):
             z,
             include_raw_state=self.include_raw_state,
         )
-        if self.detach_features:
-            rep = rep.detach()
+        # if self.detach_features:
+        #     rep = rep.detach()
         # Delegate to GaussianPolicyHead: base MLP + log_std_module
         loc = self.base(rep)
         scale = self.log_std_module(loc)
@@ -400,13 +407,14 @@ class IPMDBilinear(IPMD):
         offline_dataset_enabled = bool(
             getattr(self.config.offline_dataset, "enabled", False)
         )
+        offline_cfg = self.config.bilinear.offline_pretrain
         if (
-            self.config.bilinear.offline_pretrain.enabled
+            offline_cfg.requires_offline_data()
             and not offline_dataset_enabled
             and self._discover_env_method(env, "sample_expert_batch") is None
         ):
             msg = (
-                "bilinear.offline_pretrain.enabled=True requires "
+                "bilinear offline pretraining or policy BC requires "
                 "env.sample_expert_batch(...) or offline_dataset.enabled=True."
             )
             raise ValueError(msg)
@@ -506,14 +514,14 @@ class IPMDBilinear(IPMD):
 
     def _validate_offline_pretrain_setup(self) -> None:
         offline_cfg = self.config.bilinear.offline_pretrain
-        if not offline_cfg.enabled:
+        if not offline_cfg.requires_offline_data():
             return
         if (
             self._offline_expert_batch_sampler is None
             and self._expert_batch_sampler is None
         ):
             msg = (
-                "bilinear.offline_pretrain.enabled=True requires "
+                "bilinear offline pretraining or policy BC requires "
                 "env.sample_expert_batch(...) or offline_dataset.enabled=True."
             )
             raise ValueError(msg)
@@ -522,11 +530,28 @@ class IPMDBilinear(IPMD):
 
     def _preflight_offline_pretrain_batch(self) -> None:
         offline_cfg = self.config.bilinear.offline_pretrain
-        preflight_batch_size = min(int(offline_cfg.batch_size), 8)
+        preflight_batch_size = min(
+            int(
+                offline_cfg.batch_size
+                if offline_cfg.enabled
+                else offline_cfg.policy_bc_batch_size
+            ),
+            8,
+        )
         expert_batch = self._next_offline_expert_batch(
             batch_size=preflight_batch_size,
             required_keys=self._offline_pretrain_required_keys(),
         )
+        if offline_cfg.policy_bc_updates > 0:
+            expert_action = cast(Tensor, expert_batch.get("expert_action"))
+            self._validate_offline_pretrain_tensor_shape(
+                "expert_action",
+                expert_action,
+                batch_size=preflight_batch_size,
+                feature_dim=int(self.bilinear_rep.action_dim),
+            )
+        if not offline_cfg.enabled:
+            return
         transitions = self._sr_transition_batch_from_td(
             expert_batch,
             action_key="expert_action",
@@ -694,7 +719,9 @@ class IPMDBilinear(IPMD):
         return dedupe_keys(required)
 
     def _offline_pretrain_required_keys(self) -> list[BatchKey]:
-        required = self._offline_sr_required_keys()
+        required: list[BatchKey] = []
+        if self.config.bilinear.offline_pretrain.enabled:
+            required.extend(self._offline_sr_required_keys())
         if self.config.bilinear.offline_pretrain.policy_bc_updates > 0:
             required.extend(self._offline_policy_bc_required_keys())
         return dedupe_keys(required)
@@ -762,17 +789,20 @@ class IPMDBilinear(IPMD):
         }
 
     def _offline_policy_bc_step(self, expert_batch: TensorDict) -> dict[str, float]:
+        offline_cfg = self.config.bilinear.offline_pretrain
         expert_batch = expert_batch.to(self.device)
         expert_action = cast(Tensor, expert_batch.get("expert_action"))
         expert_obs_td = expert_batch.clone(False)
+        train_latent = bool(offline_cfg.policy_bc_train_latent)
+        bc_latent: Tensor | None = None
         if self._use_latent_command and self._latent_key not in expert_obs_td.keys(
             True
         ):
-            expert_latents = self._expert_latents_from_td(
+            bc_latent = self._expert_latents_from_td(
                 expert_batch,
-                detach=True,
+                detach=not train_latent,
             ).reshape(*expert_batch.batch_size, self._latent_dim)
-            expert_obs_td.set(self._latent_key, expert_latents)
+            expert_obs_td.set(self._latent_key, bc_latent)
         expert_obs_td = expert_obs_td.select(*self._policy_operator.in_keys)
 
         self.optim.zero_grad(set_to_none=True)
@@ -793,7 +823,11 @@ class IPMDBilinear(IPMD):
                 "bc_log_prob_mean": log_prob.mean().item(),
                 "bc_expert_action_abs_mean": expert_action.abs().mean().item(),
                 "bc_actor_grad_norm": float(grad_norm),
+                "bc_train_latent": float(train_latent),
             }
+            if bc_latent is not None:
+                metrics["bc_latent_abs_mean"] = bc_latent.abs().mean().item()
+                metrics["bc_latent_std"] = bc_latent.std(unbiased=False).item()
             scale = getattr(dist, "scale", None)
             if isinstance(scale, Tensor):
                 metrics["bc_policy_scale_mean"] = scale.mean().item()
@@ -856,67 +890,86 @@ class IPMDBilinear(IPMD):
             time.perf_counter() - start_time,
         )
 
+    def _offline_pretrain_latent_step(self) -> dict[str, float]:
+        if self._latent_learner is None:
+            return {}
+        if (
+            str(self.config.ipmd.latent_learning.method).strip().lower()
+            != "patch_vqvae"
+        ):
+            return {}
+        return self._latent_learner.update(
+            TensorDict({}, batch_size=[], device=self.device)
+        )
+
     def _offline_pretrain_spectral_representation(self) -> None:
         offline_cfg = self.config.bilinear.offline_pretrain
-        if not offline_cfg.enabled:
+        if not offline_cfg.requires_offline_data():
             return
-
-        required_keys = self._offline_pretrain_required_keys()
-        total_updates = int(offline_cfg.num_updates)
-        start_time = time.perf_counter()
-        self.log.info(
-            "offline_pretrain start | updates=%d | batch_size=%d | log_interval=%d",
-            total_updates,
-            int(offline_cfg.batch_size),
-            int(offline_cfg.log_interval),
-        )
-        for update_idx in range(1, offline_cfg.num_updates + 1):
-            expert_batch = self._next_offline_expert_batch(
-                batch_size=offline_cfg.batch_size,
-                required_keys=required_keys,
+        if offline_cfg.enabled:
+            required_keys = self._offline_sr_required_keys()
+            total_updates = int(offline_cfg.num_updates)
+            start_time = time.perf_counter()
+            self.log.info(
+                "offline_pretrain start | updates=%d | batch_size=%d | log_interval=%d",
+                total_updates,
+                int(offline_cfg.batch_size),
+                int(offline_cfg.log_interval),
             )
-            self._store_transitions(expert_batch, action_key="expert_action")
-            sr_metrics = self._train_sr_steps(1)
+            for update_idx in range(1, offline_cfg.num_updates + 1):
+                expert_batch = self._next_offline_expert_batch(
+                    batch_size=offline_cfg.batch_size,
+                    required_keys=required_keys,
+                )
+                latent_metrics = self._offline_pretrain_latent_step()
+                self._store_transitions(expert_batch, action_key="expert_action")
+                sr_metrics = self._train_sr_steps(1)
 
-            if update_idx % offline_cfg.log_interval == 0 or update_idx in {
-                1,
-                offline_cfg.num_updates,
-            }:
-                log_metrics = {
-                    f"offline/sr/{key}": value for key, value in sr_metrics.items()
-                }
-                log_metrics["offline/sr/history_buffer_size"] = float(
-                    len(self._sr_history_buffer)
-                )
-                self.log_metrics(
-                    log_metrics,
-                    step=update_idx,
-                    log_python=bool(self.config.logger.log_to_console),
-                )
-                elapsed = time.perf_counter() - start_time
-                updates_per_sec = update_idx / elapsed
-                remaining_updates = total_updates - update_idx
-                eta_seconds = remaining_updates / updates_per_sec
-                self.log.info(
-                    "offline_pretrain progress | update=%d/%d | %.1f%% | "
-                    "elapsed=%.1fs | eta=%.1fs | updates_per_sec=%.3f | "
-                    "history=%d",
-                    update_idx,
-                    total_updates,
-                    100.0 * update_idx / total_updates,
-                    elapsed,
-                    eta_seconds,
-                    updates_per_sec,
-                    len(self._sr_history_buffer),
-                )
+                if update_idx % offline_cfg.log_interval == 0 or update_idx in {
+                    1,
+                    offline_cfg.num_updates,
+                }:
+                    log_metrics = {
+                        f"offline/sr/{key}": value for key, value in sr_metrics.items()
+                    }
+                    log_metrics.update(
+                        {
+                            f"offline/latent/{key}": value
+                            for key, value in latent_metrics.items()
+                        }
+                    )
+                    log_metrics["offline/sr/history_buffer_size"] = float(
+                        len(self._sr_history_buffer)
+                    )
+                    self.log_metrics(
+                        log_metrics,
+                        step=update_idx,
+                        log_python=bool(self.config.logger.log_to_console),
+                    )
+                    elapsed = time.perf_counter() - start_time
+                    updates_per_sec = update_idx / elapsed
+                    remaining_updates = total_updates - update_idx
+                    eta_seconds = remaining_updates / updates_per_sec
+                    self.log.info(
+                        "offline_pretrain progress | update=%d/%d | %.1f%% | "
+                        "elapsed=%.1fs | eta=%.1fs | updates_per_sec=%.3f | "
+                        "history=%d",
+                        update_idx,
+                        total_updates,
+                        100.0 * update_idx / total_updates,
+                        elapsed,
+                        eta_seconds,
+                        updates_per_sec,
+                        len(self._sr_history_buffer),
+                    )
 
-        self.bilinear_rep.update_ema(1.0)
-        self.log.info(
-            "offline_pretrain complete | updates=%d | elapsed=%.1fs | history=%d",
-            total_updates,
-            time.perf_counter() - start_time,
-            len(self._sr_history_buffer),
-        )
+            self.bilinear_rep.update_ema(1.0)
+            self.log.info(
+                "offline_pretrain complete | updates=%d | elapsed=%.1fs | history=%d",
+                total_updates,
+                time.perf_counter() - start_time,
+                len(self._sr_history_buffer),
+            )
         self._offline_pretrain_policy_bc()
 
     def train(self) -> None:  # type: ignore[override]

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -73,6 +73,80 @@ class ReplayBufferConfig:
 
 
 @dataclass
+class OfflineDatasetConfig:
+    """Offline expert dataset configuration."""
+
+    enabled: bool = False
+    """Whether to build an offline expert dataset cache."""
+
+    replace_expert_sampler: bool = False
+    """Whether the offline cache replaces env.sample_expert_batch during online updates."""
+
+    source: str = "lerobot_stream"
+    """Offline source type. Supported initially: ``"lerobot_stream"``."""
+
+    repo_id: str = "unitreerobotics/G1_WBT_Brainco_Pickup_Pillow"
+    """LeRobot dataset repository id."""
+
+    split: str = "train"
+    """Dataset split to stream."""
+
+    mapper: str = "unitree_g1_wbt_29dof"
+    """Dataset-to-training TensorDict mapper."""
+
+    cache_storage: str = "torchrl_memmap"
+    """Local cache storage backend."""
+
+    cache_dir: str = ""
+    """Directory for the local TorchRL memmap cache. Empty string uses the default."""
+
+    min_ready_transitions: int = 100_000
+    """Minimum converted transitions before training may sample."""
+
+    max_cache_transitions: int = 5_000_000
+    """Maximum local cache size before round-robin overwrite."""
+
+    low_watermark: int = 1_000_000
+    """Refill watermark reserved for rolling-cache policies."""
+
+    starvation_timeout_s: float = 300.0
+    """Timeout while waiting for the background producer to fill the cache."""
+
+    local_sample_prefetch: int = 0
+    """TorchRL sampling-side prefetch for the local cache."""
+
+    batch_size: int = 0
+    """Default replay-buffer sample batch size. Use 0 to defer to sample calls."""
+
+    max_episodes: int = 0
+    """Optional cap for startup probes and bounded dataset subsets. Use 0 for no cap."""
+
+    fps: float = 30.0
+    """Dataset frame rate used for finite differences."""
+
+    episode_key: str = "episode_index"
+    """LeRobot field containing episode ids."""
+
+    robot_q_current_key: str = "observation.state.robot_q_current"
+    """LeRobot field containing current floating-base robot configuration."""
+
+    robot_q_desired_key: str = "action.robot_q_desired"
+    """LeRobot field containing desired floating-base robot configuration."""
+
+    quat_order: str = "wxyz"
+    """Quaternion order in ``robot_q_current``."""
+
+    default_joint_pos: list[float] = field(default_factory=list)
+    """G1 default joint positions in dataset joint order."""
+
+    default_joint_pos_pool: list[list[float]] = field(default_factory=list)
+    """Optional pool of G1 default joint positions for domain-randomized env offsets."""
+
+    action_scale: list[float] = field(default_factory=list)
+    """G1 action scale in dataset joint order."""
+
+
+@dataclass
 class LoggerConfig:
     """Logger configuration for RLOpt  ."""
 
@@ -357,6 +431,9 @@ class RLOptConfig:
 
     replay_buffer: ReplayBufferConfig = field(default_factory=ReplayBufferConfig)
     """Replay buffer configuration."""
+
+    offline_dataset: OfflineDatasetConfig = field(default_factory=OfflineDatasetConfig)
+    """Offline expert dataset configuration."""
 
     logger: LoggerConfig = field(default_factory=LoggerConfig)
     """Logger configuration."""

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -86,7 +86,10 @@ class OfflineDatasetConfig:
     """Offline source type. Supported initially: ``"lerobot_stream"``."""
 
     repo_id: str = "unitreerobotics/G1_WBT_Brainco_Pickup_Pillow"
-    """LeRobot dataset repository id."""
+    """Primary LeRobot dataset repository id."""
+
+    repo_ids: list[str] = field(default_factory=list)
+    """Optional ordered list of LeRobot dataset repository ids."""
 
     split: str = "train"
     """Dataset split to stream."""
@@ -121,6 +124,9 @@ class OfflineDatasetConfig:
     max_episodes: int = 0
     """Optional cap for startup probes and bounded dataset subsets. Use 0 for no cap."""
 
+    max_episodes_per_repo: int = 0
+    """Optional per-repo cap for multi-repo startup probes. Use 0 for no cap."""
+
     fps: float = 30.0
     """Dataset frame rate used for finite differences."""
 
@@ -137,13 +143,25 @@ class OfflineDatasetConfig:
     """Quaternion order in ``robot_q_current``."""
 
     default_joint_pos: list[float] = field(default_factory=list)
-    """G1 default joint positions in dataset joint order."""
+    """G1 default joint positions in target/action joint order."""
 
     default_joint_pos_pool: list[list[float]] = field(default_factory=list)
     """Optional pool of G1 default joint positions for domain-randomized env offsets."""
 
     action_scale: list[float] = field(default_factory=list)
-    """G1 action scale in dataset joint order."""
+    """G1 action scale in target/action joint order."""
+
+    dataset_joint_names: list[str] = field(default_factory=list)
+    """Optional robot_q[7:] joint names in dataset order."""
+
+    target_joint_names: list[str] = field(default_factory=list)
+    """Optional target/action joint names emitted by the mapper."""
+
+    align_root_z_to_default: bool = True
+    """Align LeRobot root z so the first frame matches the environment default."""
+
+    default_root_height: float = 0.0
+    """Optional default root height for LeRobot z alignment; 0 defers to env params."""
 
 
 @dataclass

--- a/rlopt/expert/__init__.py
+++ b/rlopt/expert/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Utilities for feeding expert demonstrations into RLOpt agents.
 
 This package provides:
@@ -14,5 +12,12 @@ They are meant to be used as a glue layer between external dataset libs
 such as ImitationLearningTools (iltools) and RLOpt algorithms.
 """
 
-from .stream import StateMapper, build_prefetch_iterator  # noqa: F401
+from __future__ import annotations
 
+from .stream import (  # noqa: F401
+    OfflineExpertSampler,
+    StateMapper,
+    StreamingOfflineExpertSampler,
+    build_offline_expert_sampler,
+    build_prefetch_iterator,
+)

--- a/rlopt/expert/stream.py
+++ b/rlopt/expert/stream.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from queue import Queue
-from typing import Callable, Iterator, Mapping, MutableMapping, Optional
+from typing import Any
 
 import torch
 from tensordict import TensorDict
+from torchrl.data import TensorDictReplayBuffer
+
+try:
+    from iltools.datasets.lerobot_stream import (
+        LeRobotStreamingCacheConfig,
+        StreamingTensorDictReplayCache,
+        UnitreeG1WBT29DofMapper,
+        UnitreeG1WBT29DofMapperConfig,
+    )
+except ImportError:
+    LeRobotStreamingCacheConfig = None  # type: ignore[assignment]
+    StreamingTensorDictReplayCache = None  # type: ignore[assignment]
+    UnitreeG1WBT29DofMapper = None  # type: ignore[assignment]
+    UnitreeG1WBT29DofMapperConfig = None  # type: ignore[assignment]
 
 
 @dataclass
@@ -26,12 +42,14 @@ class StateMapper:
         default_factory=dict
     )
     action_key: str | Callable[[TensorDict], torch.Tensor] = "action"
-    next_obs_map: Mapping[
-        str, str | Callable[[TensorDict], torch.Tensor]
-    ] = field(default_factory=dict)
+    next_obs_map: Mapping[str, str | Callable[[TensorDict], torch.Tensor]] = field(
+        default_factory=dict
+    )
 
     def _apply_map(
-        self, raw: TensorDict, mapping: Mapping[str, str | Callable[[TensorDict], torch.Tensor]]
+        self,
+        raw: TensorDict,
+        mapping: Mapping[str, str | Callable[[TensorDict], torch.Tensor]],
     ) -> TensorDict:
         out: MutableMapping[str, torch.Tensor] = {}
         for dst, spec in mapping.items():
@@ -56,12 +74,11 @@ class StateMapper:
         else:
             # passthrough if present
             obs_td = TensorDict({}, batch_size=raw.batch_size, device=raw.device)
-            if "observation" in raw.keys():
+            if "observation" in raw:
                 obs_td.set("observation", raw.get("observation"))
             else:
-                raise KeyError(
-                    "StateMapper: obs_map is empty and 'observation' not found in raw"
-                )
+                msg = "StateMapper: obs_map is empty and 'observation' not found in raw"
+                raise KeyError(msg)
 
         # action
         if isinstance(self.action_key, str):
@@ -77,20 +94,21 @@ class StateMapper:
             # support nested ('next', 'observation') or flat 'next_observation'
             if ("next", "observation") in raw.keys(True, True):
                 next_td.set(("next", "observation"), raw.get(("next", "observation")))
-            elif "next_observation" in raw.keys():
+            elif "next_observation" in raw:
                 next_td.set(("next", "observation"), raw.get("next_observation"))
             else:
-                raise KeyError(
+                msg = (
                     "StateMapper: next_obs_map is empty and next observation not found"
                 )
+                raise KeyError(msg)
 
         out = TensorDict({}, batch_size=raw.batch_size, device=raw.device)
         # Merge observation fields: if obs_td has multiple fields, concatenate under 'observation'
-        if "observation" in obs_td.keys():
+        if "observation" in obs_td:
             out.set("observation", obs_td.get("observation"))
         else:
             # Concatenate all values in insertion order
-            vals = [obs_td.get(k) for k in obs_td.keys()]
+            vals = [obs_td.get(k) for k in obs_td]
             out.set("observation", torch.cat(vals, dim=-1))
 
         out.set("action", action)
@@ -99,7 +117,7 @@ class StateMapper:
         if ("next", "observation") in next_td.keys(True, True):
             out.set(("next", "observation"), next_td.get(("next", "observation")))
         else:
-            vals = [next_td.get(k) for k in next_td.keys()]
+            vals = [next_td.get(k) for k in next_td]
             out.set(("next", "observation"), torch.cat(vals, dim=-1))
 
         return out
@@ -121,8 +139,7 @@ def build_prefetch_iterator(
     loops (e.g., IsaacLab) without stalling on H2D transfers.
     """
 
-    q: Queue[Optional[TensorDict]] = Queue(maxsize=max(1, prefetch))
-    stop_token = object()
+    q: Queue[TensorDict | None] = Queue(maxsize=max(1, prefetch))
 
     def _worker() -> None:
         try:
@@ -143,3 +160,145 @@ def build_prefetch_iterator(
             break
         yield item
 
+
+class OfflineExpertSampler:
+    """Callable adapter exposing cached TensorDict batches to IPMD."""
+
+    def __init__(
+        self,
+        replay_buffer: TensorDictReplayBuffer,
+        *,
+        required_preflight_batch_size: int = 1,
+    ) -> None:
+        if len(replay_buffer) < int(required_preflight_batch_size):
+            msg = (
+                "Offline replay buffer does not contain enough transitions for "
+                f"preflight: len={len(replay_buffer)}, required={required_preflight_batch_size}."
+            )
+            raise ValueError(msg)
+        self.replay_buffer = replay_buffer
+
+    def __call__(
+        self, batch_size: int, required_keys: list[str | tuple[str, ...]]
+    ) -> TensorDict:
+        batch = self.replay_buffer.sample(int(batch_size))
+        return batch.select(*required_keys).clone()
+
+
+class StreamingOfflineExpertSampler:
+    """Callable sampler backed by a background LeRobot-to-TorchRL cache."""
+
+    def __init__(self, cache: Any) -> None:
+        self.cache = cache
+
+    @property
+    def replay_buffer(self) -> TensorDictReplayBuffer:
+        return self.cache.replay_buffer
+
+    def __call__(
+        self, batch_size: int, required_keys: list[str | tuple[str, ...]]
+    ) -> TensorDict:
+        batch = self.cache.sample(int(batch_size))
+        return batch.select(*required_keys).clone()
+
+
+def _discover_offline_mapper_params(env: object) -> dict[str, Any]:
+    stack: list[object] = [env]
+    visited: set[int] = set()
+    while stack:
+        current = stack.pop()
+        obj_id = id(current)
+        if obj_id in visited:
+            continue
+        visited.add(obj_id)
+        method = getattr(current, "get_offline_dataset_mapper_params", None)
+        if callable(method):
+            return dict(method())
+        for attr_name in ("base_env", "env", "_env", "unwrapped"):
+            next_obj = getattr(current, attr_name, None)
+            if next_obj is None:
+                continue
+            if isinstance(next_obj, list | tuple):
+                stack.extend(next_obj)
+            else:
+                stack.append(next_obj)
+    return {}
+
+
+def build_offline_expert_sampler(
+    config: Any, env: object
+) -> StreamingOfflineExpertSampler | None:
+    """Build an optional offline expert sampler from ``config.offline_dataset``."""
+
+    offline_cfg = getattr(config, "offline_dataset", None)
+    if offline_cfg is None or not bool(offline_cfg.enabled):
+        return None
+    if str(offline_cfg.source) != "lerobot_stream":
+        msg = f"Unsupported offline_dataset.source={offline_cfg.source!r}."
+        raise ValueError(msg)
+    if str(offline_cfg.mapper) != "unitree_g1_wbt_29dof":
+        msg = f"Unsupported offline_dataset.mapper={offline_cfg.mapper!r}."
+        raise ValueError(msg)
+    if str(offline_cfg.cache_storage) != "torchrl_memmap":
+        msg = (
+            f"Unsupported offline_dataset.cache_storage={offline_cfg.cache_storage!r}."
+        )
+        raise ValueError(msg)
+
+    params = _discover_offline_mapper_params(env)
+    default_joint_pos_pool = list(offline_cfg.default_joint_pos_pool) or list(
+        params.get("default_joint_pos_pool", [])
+    )
+    default_joint_pos = list(offline_cfg.default_joint_pos) or list(
+        params.get("default_joint_pos", [])
+    )
+    action_scale = list(offline_cfg.action_scale) or list(
+        params.get("action_scale", [])
+    )
+    cache_dir = str(offline_cfg.cache_dir)
+    if not cache_dir:
+        cache_dir = str(Path("offline_dataset_cache") / str(offline_cfg.mapper))
+
+    if (
+        LeRobotStreamingCacheConfig is None
+        or StreamingTensorDictReplayCache is None
+        or UnitreeG1WBT29DofMapper is None
+        or UnitreeG1WBT29DofMapperConfig is None
+    ):
+        msg = (
+            "RLOpt offline_dataset.source='lerobot_stream' requires "
+            "ImitationLearningTools with the LeRobot streaming utilities."
+        )
+        raise ImportError(msg)
+
+    mapper_cfg = UnitreeG1WBT29DofMapperConfig(
+        robot_q_current_key=str(offline_cfg.robot_q_current_key),
+        robot_q_desired_key=str(offline_cfg.robot_q_desired_key),
+        episode_key=str(offline_cfg.episode_key),
+        dt=1.0 / float(offline_cfg.fps),
+        default_joint_pos=default_joint_pos_pool or default_joint_pos,
+        action_scale=action_scale,
+        quat_order=str(offline_cfg.quat_order),
+    )
+    mapper = UnitreeG1WBT29DofMapper(mapper_cfg)
+    cache_cfg = LeRobotStreamingCacheConfig(
+        repo_id=str(offline_cfg.repo_id),
+        split=str(offline_cfg.split),
+        cache_dir=cache_dir,
+        max_cache_transitions=int(offline_cfg.max_cache_transitions),
+        min_ready_transitions=int(offline_cfg.min_ready_transitions),
+        low_watermark=int(offline_cfg.low_watermark),
+        starvation_timeout_s=float(offline_cfg.starvation_timeout_s),
+        local_sample_prefetch=int(offline_cfg.local_sample_prefetch),
+        batch_size=None
+        if int(offline_cfg.batch_size) <= 0
+        else int(offline_cfg.batch_size),
+        max_episodes=None
+        if int(offline_cfg.max_episodes) <= 0
+        else int(offline_cfg.max_episodes),
+        mapper=mapper_cfg,
+    )
+    cache = StreamingTensorDictReplayCache(cache_cfg, mapper=mapper)
+    cache.start()
+    cache.wait_until_ready()
+    return StreamingOfflineExpertSampler(cache)

--- a/rlopt/expert/stream.py
+++ b/rlopt/expert/stream.py
@@ -255,6 +255,18 @@ def build_offline_expert_sampler(
     action_scale = list(offline_cfg.action_scale) or list(
         params.get("action_scale", [])
     )
+    dataset_joint_names = list(offline_cfg.dataset_joint_names) or list(
+        params.get("dataset_joint_names", [])
+    )
+    target_joint_names = list(offline_cfg.target_joint_names) or list(
+        params.get("target_joint_names", params.get("joint_names", []))
+    )
+    default_root_height = float(offline_cfg.default_root_height)
+    if default_root_height == 0.0:
+        default_root_height = float(params.get("default_root_height", 0.0))
+    align_root_z_to_default = bool(
+        offline_cfg.align_root_z_to_default and default_root_height > 0.0
+    )
     cache_dir = str(offline_cfg.cache_dir)
     if not cache_dir:
         cache_dir = str(Path("offline_dataset_cache") / str(offline_cfg.mapper))
@@ -278,11 +290,16 @@ def build_offline_expert_sampler(
         dt=1.0 / float(offline_cfg.fps),
         default_joint_pos=default_joint_pos_pool or default_joint_pos,
         action_scale=action_scale,
+        dataset_joint_names=dataset_joint_names,
+        target_joint_names=target_joint_names,
+        align_root_z_to_default=align_root_z_to_default,
+        default_root_height=default_root_height,
         quat_order=str(offline_cfg.quat_order),
     )
     mapper = UnitreeG1WBT29DofMapper(mapper_cfg)
     cache_cfg = LeRobotStreamingCacheConfig(
         repo_id=str(offline_cfg.repo_id),
+        repo_ids=tuple(str(repo_id) for repo_id in offline_cfg.repo_ids),
         split=str(offline_cfg.split),
         cache_dir=cache_dir,
         max_cache_transitions=int(offline_cfg.max_cache_transitions),
@@ -296,6 +313,9 @@ def build_offline_expert_sampler(
         max_episodes=None
         if int(offline_cfg.max_episodes) <= 0
         else int(offline_cfg.max_episodes),
+        max_episodes_per_repo=None
+        if int(offline_cfg.max_episodes_per_repo) <= 0
+        else int(offline_cfg.max_episodes_per_repo),
         mapper=mapper_cfg,
     )
     cache = StreamingTensorDictReplayCache(cache_cfg, mapper=mapper)

--- a/tests/test_offline_dataset.py
+++ b/tests/test_offline_dataset.py
@@ -15,13 +15,19 @@ def test_offline_dataset_config_defaults_to_unitree_wbt_lerobot() -> None:
     assert cfg.offline_dataset.replace_expert_sampler is False
     assert cfg.offline_dataset.source == "lerobot_stream"
     assert cfg.offline_dataset.repo_id == "unitreerobotics/G1_WBT_Brainco_Pickup_Pillow"
+    assert cfg.offline_dataset.repo_ids == []
     assert cfg.offline_dataset.split == "train"
     assert cfg.offline_dataset.mapper == "unitree_g1_wbt_29dof"
     assert cfg.offline_dataset.cache_storage == "torchrl_memmap"
     assert cfg.offline_dataset.cache_dir == ""
     assert cfg.offline_dataset.batch_size == 0
     assert cfg.offline_dataset.max_episodes == 0
+    assert cfg.offline_dataset.max_episodes_per_repo == 0
     assert cfg.offline_dataset.default_joint_pos_pool == []
+    assert cfg.offline_dataset.dataset_joint_names == []
+    assert cfg.offline_dataset.target_joint_names == []
+    assert cfg.offline_dataset.align_root_z_to_default is True
+    assert cfg.offline_dataset.default_root_height == 0.0
 
 
 def test_offline_expert_sampler_selects_required_tensordict_keys() -> None:

--- a/tests/test_offline_dataset.py
+++ b/tests/test_offline_dataset.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+
+from rlopt.config_base import RLOptConfig
+from rlopt.expert import OfflineExpertSampler
+
+
+def test_offline_dataset_config_defaults_to_unitree_wbt_lerobot() -> None:
+    cfg = RLOptConfig()
+
+    assert cfg.offline_dataset.enabled is False
+    assert cfg.offline_dataset.replace_expert_sampler is False
+    assert cfg.offline_dataset.source == "lerobot_stream"
+    assert cfg.offline_dataset.repo_id == "unitreerobotics/G1_WBT_Brainco_Pickup_Pillow"
+    assert cfg.offline_dataset.split == "train"
+    assert cfg.offline_dataset.mapper == "unitree_g1_wbt_29dof"
+    assert cfg.offline_dataset.cache_storage == "torchrl_memmap"
+    assert cfg.offline_dataset.cache_dir == ""
+    assert cfg.offline_dataset.batch_size == 0
+    assert cfg.offline_dataset.max_episodes == 0
+    assert cfg.offline_dataset.default_joint_pos_pool == []
+
+
+def test_offline_expert_sampler_selects_required_tensordict_keys() -> None:
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(max_size=8),
+        batch_size=2,
+    )
+    replay_buffer.extend(
+        TensorDict(
+            {
+                ("policy", "joint_pos_rel"): torch.randn(4, 29),
+                ("next", "policy", "joint_pos_rel"): torch.randn(4, 29),
+                "expert_action": torch.randn(4, 29),
+                "unused": torch.randn(4, 3),
+            },
+            batch_size=[4],
+        )
+    )
+    sampler = OfflineExpertSampler(replay_buffer)
+
+    batch = sampler(
+        2,
+        [
+            ("policy", "joint_pos_rel"),
+            ("next", "policy", "joint_pos_rel"),
+            "expert_action",
+        ],
+    )
+
+    assert batch.numel() == 2
+    assert ("policy", "joint_pos_rel") in batch.keys(True)
+    assert ("next", "policy", "joint_pos_rel") in batch.keys(True)
+    assert "expert_action" in batch.keys(True)
+    assert "unused" not in batch.keys(True)


### PR DESCRIPTION
## Summary

- Add latent learner checkpoint persistence and continuous posterior-command hold support.
- Make bilinear offline policy BC usable independently of SR pretraining and optionally train posterior latent modules through BC.
- Add VQ-VAE latent joint-parameter support and offline latent update hooks for bilinear pretraining experiments.

## Validation

- `git diff --check`

## Parent PR

Supports GTLIDAR/IsaacLab-Imitation#8.