### PR TITLE
Fix concat policy representation and remove useless f_hidden_dims

### DIFF
--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -139,9 +139,6 @@ class BilinearSRConfig:
     embed_dim: int = 512
     """Shared embedding dimension for state and action encoders."""
 
-    f_hidden_dims: tuple[int, ...] = (512, 512)
-    """Hidden layers for state encoder f(s)."""
-
     g_hidden_dims: tuple[int, ...] = (512,)
     """Hidden layers for action encoder g(a)."""
 
@@ -496,7 +493,6 @@ class IPMDBilinear(IPMD):
             "action_dim": action_spec.shape[-1],
             "feature_dim": cfg.feature_dim,
             "embed_dim": cfg.embed_dim,
-            "f_hidden_dims": cfg.f_hidden_dims,
             "g_hidden_dims": cfg.g_hidden_dims,
             "mu_hidden_dims": cfg.mu_hidden_dims,
             "num_noises": cfg.num_noises,

--- a/rlopt/agent/ipmd/module.py
+++ b/rlopt/agent/ipmd/module.py
@@ -79,7 +79,6 @@ class BilinearSR(ABC, nn.Module):
         action_dim: int,
         feature_dim: int,
         embed_dim: int,
-        f_hidden_dims: tuple[int, ...],
         g_hidden_dims: tuple[int, ...],
         use_ema_for_policy: bool = True,
         device: str | torch.device = "cpu",
@@ -158,9 +157,9 @@ class BilinearSR(ABC, nn.Module):
         *,
         include_raw_state: bool = True,
     ) -> Tensor:
-        """F(s) z -> (B, embed_dim). Optionally append raw SR state."""
-        F_s = self._F(s, use_ema=True).detach()
-        component1 = torch.einsum("bef,bf->be", F_s, z)
+        net = self.state_net_ema if self.state_net_ema is not None else self.state_net
+        state_embed = net(s).detach()
+        component1 = torch.concat([state_embed, z], dim=-1)
         if include_raw_state:
             return torch.concat([component1, s.detach()], dim=-1)
         return component1
@@ -227,7 +226,6 @@ class DiffSRBilinear(BilinearSR):
         action_dim: int,
         feature_dim: int,
         embed_dim: int,
-        f_hidden_dims: tuple[int, ...],
         g_hidden_dims: tuple[int, ...],
         mu_hidden_dims: tuple[int, ...],
         num_noises: int = 16,
@@ -242,7 +240,6 @@ class DiffSRBilinear(BilinearSR):
             action_dim=action_dim,
             feature_dim=feature_dim,
             embed_dim=embed_dim,
-            f_hidden_dims=f_hidden_dims,
             g_hidden_dims=g_hidden_dims,
             use_ema_for_policy=use_ema_for_policy,
             device=device,
@@ -415,7 +412,6 @@ class SpederBilinear(BilinearSR):
         action_dim: int,
         feature_dim: int,
         embed_dim: int,
-        f_hidden_dims: tuple[int, ...],
         g_hidden_dims: tuple[int, ...],
         mu_hidden_dims: tuple[int, ...],
         num_noises: int = 25,
@@ -429,7 +425,6 @@ class SpederBilinear(BilinearSR):
             action_dim=action_dim,
             feature_dim=feature_dim,
             embed_dim=embed_dim,
-            f_hidden_dims=f_hidden_dims,
             g_hidden_dims=g_hidden_dims,
             use_ema_for_policy=use_ema_for_policy,
             device=device,
@@ -585,7 +580,6 @@ class CtrlSRBilinear(BilinearSR):
         action_dim: int,
         feature_dim: int,
         embed_dim: int,
-        f_hidden_dims: tuple[int, ...],
         g_hidden_dims: tuple[int, ...],
         mu_hidden_dims: tuple[int, ...],
         num_noises: int = 16,
@@ -598,7 +592,6 @@ class CtrlSRBilinear(BilinearSR):
             action_dim=action_dim,
             feature_dim=feature_dim,
             embed_dim=embed_dim,
-            f_hidden_dims=f_hidden_dims,
             g_hidden_dims=g_hidden_dims,
             use_ema_for_policy=use_ema_for_policy,
             device=device,

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -147,7 +147,6 @@ def _make_bilinear_offline_cfg():
     cfg.bilinear.next_obs_keys = ["observation"]
     cfg.bilinear.feature_dim = 3
     cfg.bilinear.embed_dim = 8
-    cfg.bilinear.f_hidden_dims = (16,)
     cfg.bilinear.g_hidden_dims = (16,)
     cfg.bilinear.mu_hidden_dims = (16,)
     cfg.bilinear.sr_batch_size = 4
@@ -205,7 +204,6 @@ def test_bilinear_policy_head_splits_command_from_representation_state() -> None
         action_dim=2,
         feature_dim=3,
         embed_dim=4,
-        f_hidden_dims=(8,),
         g_hidden_dims=(8,),
         mu_hidden_dims=(8,),
         num_noises=2,
@@ -230,7 +228,7 @@ def test_bilinear_policy_head_splits_command_from_representation_state() -> None
 
     assert loc.shape == (6, 2)
     assert scale.shape == (6, 2)
-    assert head.base[0].in_features == 4
+    assert head.base[0].in_features == 7
 
     raw_state_head = BilinearPolicyHead(
         bilinear_rep=bilinear_rep,
@@ -250,7 +248,7 @@ def test_bilinear_policy_head_splits_command_from_representation_state() -> None
 
     assert loc.shape == (6, 2)
     assert scale.shape == (6, 2)
-    assert raw_state_head.base[0].in_features == 9
+    assert raw_state_head.base[0].in_features == 12
 
 
 def test_ipmd_prepare_rollout_rewards_ignores_estimator_when_disabled():


### PR DESCRIPTION
# Discreption

- Fix `compute_policy_representation` to use the new concat policy representation.
- Remove the unused `f_hidden_dims`.
- Update the policy head dimension test for the concat representation.
