### PR TITLE
Fix high-level skill encoder after concat representation

### DIFF
--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -131,7 +131,6 @@ def _build_diffsr(
         action_dim=config.z_dim,
         feature_dim=config.diffsr_feature_dim,
         embed_dim=config.diffsr_embed_dim,
-        f_hidden_dims=config.diffsr_f_hidden_dims,
         g_hidden_dims=config.diffsr_g_hidden_dims,
         mu_hidden_dims=config.diffsr_mu_hidden_dims,
         num_noises=config.diffsr_num_noises,
@@ -1610,8 +1609,11 @@ class HighLevelSkillDiffSRTrainer:
         batch = self._sample_macro_batch(
             self.config.batch_size, split=self.config.train_split
         )
-        state, future_window, target = self._validate_macro_batch(
-            batch, batch_size=self.config.batch_size
+        state, future_window, target = _validate_macro_batch(
+            batch,
+            batch_size=self.config.batch_size,
+            horizon_steps=int(self.config.horizon_steps),
+            device=self.device,
         )
         self.diffsr.update_obs_norm(target.detach())
         # reg_loss is the per-method latent regularizer (L2 / KL / commitment / 0),
@@ -1674,8 +1676,11 @@ class HighLevelSkillDiffSRTrainer:
         accum: dict[str, float] = {}
         for _ in range(num_batches):
             batch = self._sample_macro_batch(batch_size, split=split)
-            state, future_window, target = self._validate_macro_batch(
-                batch, batch_size=batch_size
+            state, future_window, target = _validate_macro_batch(
+                batch,
+                batch_size=batch_size,
+                horizon_steps=int(self.config.horizon_steps),
+                device=self.device,
             )
             z, *_ = self._encode_skill(state, future_window, deterministic=True)
             zero_z = torch.zeros_like(z)

--- a/rlopt/agent/skill_commander.py
+++ b/rlopt/agent/skill_commander.py
@@ -38,7 +38,6 @@ from torch import Tensor, nn
 from rlopt.agent.hl_skill_diffsr import (
     FrozenHighLevelSkillCommandSampler,
     HighLevelSkillDiffSRConfig,
-    HighLevelSkillEncoder,
     _jsonable,
     _normalize_command_mode,
     _normalize_split_value,
@@ -47,6 +46,7 @@ from rlopt.agent.hl_skill_diffsr import (
     _require_positive_float,
     _require_positive_int,
 )
+from rlopt.agent.hl_skill_encoder import build_skill_encoder
 
 
 def _require_probability(name: str, value: float) -> float:
@@ -990,11 +990,12 @@ class SkillCommanderTrainer:
         self.state_dim = int(state.shape[-1])
         self.planner_state_dim = int(planner_state.shape[-1])
 
-        self.skill_encoder = HighLevelSkillEncoder(
+        self.skill_encoder = build_skill_encoder(
             state_dim=self.state_dim,
             window_steps=self.encoder_window_steps,
             z_dim=self.z_dim,
             hidden_dims=self.skill_config.encoder_hidden_dims,
+            spec=self.skill_config.latent_spec(),
         ).to(self.device)
         self.skill_encoder.load_state_dict(skill_checkpoint["skill_encoder_state_dict"])
         self.skill_encoder.eval()


### PR DESCRIPTION
# Description

-  Remove useless `f_hidden_dims`
-  Use `build_skill_encoder`  instead of importing `HighLevelSkillEncoder` from old motion
- Fix training calls to use `_validate_macro_batch`