### PR TITLE
Clean up frozen skill commander sampler hooks

### DIFF
--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -521,7 +521,7 @@ class FrozenHighLevelSkillCommandSampler:
             if phase_period is not None
             else self.latent_steps_max
         )
-        self.device = _resolve_device(device, env)
+        self.device = self._resolve_device(device, env)
         self._current_macro_sampler = discover_env_method(
             env,
             "current_expert_macro_transition_batch",
@@ -607,9 +607,7 @@ class FrozenHighLevelSkillCommandSampler:
         self.initial_skill_encoder.eval()
         self.initial_skill_encoder.requires_grad_(False)
 
-        self.diffsr = _build_diffsr(self.config, self.state_dim, self.device).to(
-            self.device
-        )
+        self.diffsr = self._build_diffsr().to(self.device)
         diffsr_state = checkpoint.get("diffsr_state_dict")
         if diffsr_state is None and (self.finetune_enabled or self.command_mode != "z"):
             msg = (
@@ -674,6 +672,32 @@ class FrozenHighLevelSkillCommandSampler:
             raise ValueError(msg)
         return input_dim // divisor
 
+    @staticmethod
+    def _resolve_device(
+        device: torch.device | str | None,
+        env: object,
+    ) -> torch.device:
+        return _resolve_device(device, env)
+
+    def _build_diffsr(self) -> nn.Module:
+        return _build_diffsr(self.config, self.state_dim, self.device)
+
+    def _validate_macro_batch(
+        self,
+        batch: TensorDictBase,
+        *,
+        batch_size: int,
+        source: str,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        return _validate_macro_batch(
+            batch,
+            batch_size=int(batch_size),
+            horizon_steps=int(self.config.horizon_steps),
+            device=self.device,
+            state_dim=self.state_dim,
+            source=source,
+        )
+
     def _command_code_dim_for_mode(self) -> int:
         if self.command_mode == "z":
             return int(self.config.z_dim)
@@ -737,12 +761,9 @@ class FrozenHighLevelSkillCommandSampler:
             eval_fraction=float(self.config.eval_trajectory_fraction),
             split_seed=int(self.config.trajectory_split_seed),
         )
-        return _validate_macro_batch(
+        return self._validate_macro_batch(
             batch,
             batch_size=int(batch_size),
-            horizon_steps=int(self.config.horizon_steps),
-            device=self.device,
-            state_dim=self.state_dim,
             source="Offline expert",
         )
 
@@ -775,12 +796,9 @@ class FrozenHighLevelSkillCommandSampler:
             env_ids=env_ids,
         )
         batch_size = int(env_ids.numel())
-        state, future_window, target = _validate_macro_batch(
+        state, future_window, target = self._validate_macro_batch(
             batch,
             batch_size=batch_size,
-            horizon_steps=int(self.config.horizon_steps),
-            device=self.device,
-            state_dim=self.state_dim,
             source="Current expert",
         )
         z = self.skill_encoder(state, _encoder_input_window(self.config, future_window))

--- a/rlopt/agent/skill_commander.py
+++ b/rlopt/agent/skill_commander.py
@@ -1724,7 +1724,7 @@ class FrozenSkillCommanderSampler(FrozenHighLevelSkillCommandSampler):
             if phase_period is not None
             else self.latent_steps_max
         )
-        self.device = self._resolve_device(env, device)
+        self.device = self._resolve_device(device, env)
 
         self._current_macro_sampler = discover_env_method(
             env, "current_expert_macro_transition_batch"
@@ -1820,10 +1820,10 @@ class FrozenSkillCommanderSampler(FrozenHighLevelSkillCommandSampler):
         self.generator.eval()
         self.generator.requires_grad_(False)
 
-        # DiffSR is only needed to expand z -> phi for non-z command modes; load
-        # it from the source skill checkpoint the generator distilled against.
-        self.diffsr = self._build_diffsr().to(self.device)
+        # DiffSR is only needed to expand z -> phi for non-z command modes.
+        self.diffsr = None
         if self.command_mode != "z":
+            self.diffsr = self._build_diffsr().to(self.device)
             skill_checkpoint_path = str(checkpoint.get("skill_checkpoint_path", ""))
             skill_checkpoint = torch.load(
                 Path(skill_checkpoint_path).expanduser(),
@@ -1844,8 +1844,8 @@ class FrozenSkillCommanderSampler(FrozenHighLevelSkillCommandSampler):
             obs_norm = getattr(self.diffsr, "obs_norm", None)
             if isinstance(obs_norm, nn.Module) and feature_norm_state:
                 obs_norm.load_state_dict(feature_norm_state)
-        self.diffsr.eval()
-        self.diffsr.requires_grad_(False)
+            self.diffsr.eval()
+            self.diffsr.requires_grad_(False)
 
         if self.condition_on_language:
             names_provider = discover_env_method(env, "expert_trajectory_motion_names")


### PR DESCRIPTION
# Description

- Avoid loading DiffSR for z-only skill commander checkpoints.
- Reuse sampler helper hooks from the frozen high-level skill sampler.
