### PR TITLE
Support SONIC-style training contracts in PPO/IPMD

### DIFF
--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -47,6 +47,7 @@ from rlopt.agent.ppo.ppo import (
     PPOIterationData,
     PPORLOptConfig,
     PPOTrainingMetadata,
+    _normalize_advantage_over_rollout,
 )
 from rlopt.config_utils import (
     BatchKey,
@@ -574,8 +575,27 @@ class IPMDConfig(PPOConfig):
     demonstration observations.
     """
 
+    rollout_bc_loss_type: str = "nll"
+    """Loss used for live-state action supervision: ``"nll"`` or ``"mse"``.
+
+    ``"nll"`` preserves the probabilistic behavior-cloning objective. ``"mse"``
+    supervises the deterministic policy mean and is useful when matching an
+    action-reconstruction auxiliary objective independently of exploration std.
+    """
+
     rollout_bc_action_key: ObsKey = ("policy_supervision", "expert_action")
     """Rollout observation key containing the aligned expert action label."""
+
+    actor_learning_rate: float | None = None
+    """Optional actor-specific learning rate for PPO/IPMD.
+
+    When set together with ``critic_learning_rate``, the main optimizer uses
+    separate actor and critic parameter groups. The adaptive KL schedule updates
+    only the actor group, matching asymmetric actor/critic PPO recipes.
+    """
+
+    critic_learning_rate: float | None = None
+    """Optional critic-specific learning rate for PPO/IPMD."""
 
     def validate(self) -> None:
         self.command_source = normalize_ipmd_command_source(self.command_source)
@@ -852,6 +872,31 @@ class IPMDConfig(PPOConfig):
         require_non_negative("ipmd.env_reward_weight", self.env_reward_weight)
         require_non_negative("ipmd.bc_coef", self.bc_coef)
         require_non_negative("ipmd.rollout_bc_coef", self.rollout_bc_coef)
+        if self.actor_learning_rate is not None and self.actor_learning_rate <= 0.0:
+            msg = (
+                "ipmd.actor_learning_rate must be > 0 when configured, got "
+                f"{self.actor_learning_rate!r}."
+            )
+            raise ValueError(msg)
+        if self.critic_learning_rate is not None and self.critic_learning_rate <= 0.0:
+            msg = (
+                "ipmd.critic_learning_rate must be > 0 when configured, got "
+                f"{self.critic_learning_rate!r}."
+            )
+            raise ValueError(msg)
+        if (self.actor_learning_rate is None) != (self.critic_learning_rate is None):
+            msg = (
+                "ipmd.actor_learning_rate and ipmd.critic_learning_rate must be "
+                "configured together."
+            )
+            raise ValueError(msg)
+        self.rollout_bc_loss_type = str(self.rollout_bc_loss_type).strip().lower()
+        if self.rollout_bc_loss_type not in {"nll", "mse"}:
+            msg = (
+                "ipmd.rollout_bc_loss_type must be 'nll' or 'mse', got "
+                f"{self.rollout_bc_loss_type!r}."
+            )
+            raise ValueError(msg)
         self.rollout_bc_action_key = normalize_batch_key(self.rollout_bc_action_key)
         if int(self.bc_pretrain_updates) < 0:
             msg = (
@@ -1015,6 +1060,10 @@ class IPMD(PPO):
         self._reconstruction_target_obs_keys: list[ObsKey] = dedupe_keys(
             [normalize_batch_key(key) for key in target_keys]
         )
+        self._uses_internal_latent_learner = bool(
+            self._use_latent_command
+            and self._command_source not in ("hl_skill", "skill_commander")
+        )
         self._current_reference_obs_getter = None
 
         available_keys = set(env.observation_spec.keys(True))
@@ -1035,14 +1084,16 @@ class IPMD(PPO):
                 msg += self._latent_mode_hint()
                 raise ValueError(msg)
 
-        all_obs_keys = dedupe_keys(
-            self._policy_obs_keys
-            + self._value_obs_keys
-            + self._reward_obs_keys
-            + self._posterior_obs_keys
-            + self._prior_obs_keys
-            + self._reconstruction_target_obs_keys
+        all_obs_keys = list(
+            self._policy_obs_keys + self._value_obs_keys + self._reward_obs_keys
         )
+        if self._uses_internal_latent_learner:
+            all_obs_keys.extend(
+                self._posterior_obs_keys
+                + self._prior_obs_keys
+                + self._reconstruction_target_obs_keys
+            )
+        all_obs_keys = dedupe_keys(all_obs_keys)
         if (
             float(self.config.ipmd.rollout_bc_coef) > 0.0
             and self._rollout_bc_action_key in all_obs_keys
@@ -1166,10 +1217,7 @@ class IPMD(PPO):
         else:
             self._reward_out_fn = lambda r: r
 
-        if self._use_latent_command and self._command_source not in (
-            "hl_skill",
-            "skill_commander",
-        ):
+        if self._uses_internal_latent_learner:
             method = str(self.config.ipmd.latent_learning.method)
             self._latent_learner = build_latent_learner(method)
             self._latent_learner.initialize(self)
@@ -1765,7 +1813,33 @@ class IPMD(PPO):
         ):
             joint_params = list(self._latent_learner.joint_parameters())
 
+        split_actor_critic_lr = self.config.ipmd.actor_learning_rate is not None
+        if split_actor_critic_lr:
+            assert self.config.ipmd.critic_learning_rate is not None
+            policy_params = list(self.policy.parameters()) + joint_params
+            value_params = list(self.value_function.parameters())
+            optimizer_params: list[dict[str, Any]] = [
+                {
+                    "params": policy_params,
+                    "lr": float(self.config.ipmd.actor_learning_rate),
+                    "adaptive_lr": True,
+                    "lr_min": self.config.optim.min_lr,
+                    "lr_max": self.config.optim.max_lr,
+                    "name": "actor",
+                },
+                {
+                    "params": value_params,
+                    "lr": float(self.config.ipmd.critic_learning_rate),
+                    "adaptive_lr": False,
+                    "name": "critic",
+                },
+            ]
+        else:
+            optimizer_params = []
+
         if not hasattr(self, "reward_estimator"):
+            if split_actor_critic_lr:
+                return [optimizer_cls(optimizer_params, **optimizer_kwargs)]
             if not joint_params:
                 return super()._set_optimizers(optimizer_cls, optimizer_kwargs)
             all_params = list(self.actor_critic.parameters()) + joint_params
@@ -1783,6 +1857,8 @@ class IPMD(PPO):
             self.reward_estimator.parameters(),
             **reward_optimizer_kwargs,
         )
+        if split_actor_critic_lr:
+            return [optimizer_cls(optimizer_params, **optimizer_kwargs)]
         return [optimizer_cls(policy_params, **optimizer_kwargs)]
 
     def _next_expert_batch(
@@ -2120,6 +2196,7 @@ class IPMD(PPO):
             "bc_policy_scale_mean",
             "loss_rollout_bc",
             "rollout_bc_nll",
+            "rollout_bc_mse",
             "rollout_bc_log_prob_mean",
             "rollout_bc_target_abs_mean",
             "rollout_bc_policy_action_abs_mean",
@@ -2370,14 +2447,21 @@ class IPMD(PPO):
         log_prob = dist.log_prob(target)
         log_prob = self._reduce_log_prob(log_prob, target)
         rollout_bc_nll = -log_prob.mean()
-        rollout_bc_loss = rollout_bc_nll * self._rollout_bc_coeff
-        rollout_bc_loss.backward()
-
         policy_action = dist.deterministic_sample
         error = policy_action - target
+        rollout_bc_mse = error.square().mean()
+        rollout_bc_objective = (
+            rollout_bc_mse
+            if self.config.ipmd.rollout_bc_loss_type == "mse"
+            else rollout_bc_nll
+        )
+        rollout_bc_loss = rollout_bc_objective * self._rollout_bc_coeff
+        rollout_bc_loss.backward()
+
         return {
             "loss_rollout_bc": rollout_bc_loss.detach(),
             "rollout_bc_nll": rollout_bc_nll.detach(),
+            "rollout_bc_mse": rollout_bc_mse.detach(),
             "rollout_bc_log_prob_mean": log_prob.detach().mean(),
             "rollout_bc_target_abs_mean": target.detach().abs().mean(),
             "rollout_bc_policy_action_abs_mean": policy_action.detach().abs().mean(),
@@ -2889,8 +2973,18 @@ class IPMD(PPO):
 
     def pre_iteration_compute(self, rollout: TensorDict) -> TensorDict:
         """Compute advantages."""
-        with torch.no_grad():
+        with torch.no_grad(), self._freeze_value_normalizer_updates():
             rollout = self.adv_module(rollout)
+
+            if (
+                self.config.ppo.normalize_advantage
+                and self.config.ppo.normalize_advantage_global
+            ):
+                advantage = rollout.get("advantage")
+                rollout.set(
+                    "advantage",
+                    _normalize_advantage_over_rollout(advantage),
+                )
 
             if getattr(self.config.compile, "compile", False):
                 rollout = rollout.clone()

--- a/rlopt/agent/ppo/ppo.py
+++ b/rlopt/agent/ppo/ppo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import time
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar, cast
 
@@ -56,6 +57,18 @@ from rlopt.utils import get_activation_class, log_info
 PpoCfgT = TypeVar("PpoCfgT", bound="PPORLOptConfig")
 
 
+def _normalize_advantage_over_rollout(advantage: Tensor) -> Tensor:
+    """Normalize advantages over every rollout batch dimension once."""
+    reduce_dims = tuple(range(max(advantage.ndim - 1, 1)))
+    advantage_mean = advantage.mean(dim=reduce_dims, keepdim=True)
+    advantage_std = advantage.std(
+        dim=reduce_dims,
+        keepdim=True,
+        correction=1,
+    )
+    return (advantage - advantage_mean) / (advantage_std + 1.0e-8)
+
+
 class CatInputs(torch.nn.Module):
     """Concatenate multiple input tensors along the last dimension.
 
@@ -72,6 +85,99 @@ class CatInputs(torch.nn.Module):
         if len(inputs) == 1:
             return self.module(inputs[0])
         return self.module(torch.cat(inputs, dim=-1))
+
+
+class RunningMeanStdCatInputs(torch.nn.Module):
+    """Concatenate inputs and apply SONIC-style running normalization."""
+
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        feature_dim: int,
+        *,
+        epsilon: float = 1.0e-5,
+        clip: float = 5.0,
+        normalize_mask: Tensor | None = None,
+    ) -> None:
+        super().__init__()
+        if feature_dim <= 0:
+            msg = "feature_dim must be positive."
+            raise ValueError(msg)
+        if epsilon <= 0.0:
+            msg = "epsilon must be positive."
+            raise ValueError(msg)
+        if clip <= 0.0:
+            msg = "clip must be positive."
+            raise ValueError(msg)
+        self.module = module
+        self.epsilon = float(epsilon)
+        self.clip = float(clip)
+        module_device = next(module.parameters(), torch.empty(0)).device
+        self.register_buffer(
+            "running_mean", torch.zeros(feature_dim, device=module_device)
+        )
+        self.register_buffer(
+            "running_var", torch.ones(feature_dim, device=module_device)
+        )
+        self.register_buffer(
+            "count", torch.ones((), dtype=torch.float32, device=module_device)
+        )
+        if normalize_mask is None:
+            self.normalize_mask: Tensor | None = None
+        else:
+            normalize_mask = normalize_mask.reshape(-1).to(torch.bool)
+            if normalize_mask.shape[0] != feature_dim:
+                msg = (
+                    "normalize_mask length "
+                    f"{normalize_mask.shape[0]} != feature_dim {feature_dim}."
+                )
+                raise ValueError(msg)
+            # All-True masks are equivalent to no mask; store None to skip the
+            # extra where() in forward.
+            if bool(normalize_mask.all()):
+                self.normalize_mask = None
+            else:
+                self.register_buffer("normalize_mask", normalize_mask.to(module_device))
+
+    def _concatenate(self, inputs: tuple[Tensor, ...]) -> Tensor:
+        if len(inputs) == 1:
+            return inputs[0]
+        return torch.cat(inputs, dim=-1)
+
+    @torch.no_grad()
+    def _update(self, value: Tensor) -> None:
+        flat = value.detach().reshape(-1, value.shape[-1]).to(torch.float32)
+        if flat.shape[0] == 0:
+            return
+        batch_mean = flat.mean(dim=0)
+        batch_var = flat.var(dim=0, correction=1 if flat.shape[0] > 1 else 0)
+        batch_count = float(flat.shape[0])
+        delta = batch_mean - self.running_mean
+        total_count = self.count + batch_count
+        new_mean = self.running_mean + delta * batch_count / total_count
+        mean_a = self.running_var * self.count
+        mean_b = batch_var * batch_count
+        second_moment = (
+            mean_a + mean_b + delta.square() * self.count * batch_count / total_count
+        )
+        self.running_mean.copy_(new_mean)
+        self.running_var.copy_(second_moment / total_count)
+        self.count.copy_(total_count)
+
+    def forward(self, *inputs: Tensor) -> Tensor:
+        value = self._concatenate(inputs)
+        normalized = (value - self.running_mean) / torch.sqrt(
+            self.running_var + self.epsilon
+        )
+        normalized = torch.clamp(normalized, -self.clip, self.clip)
+        if self.normalize_mask is not None:
+            # Excluded features (e.g. pretrained latent commands) pass through
+            # with their original scale and geometry.
+            normalized = torch.where(self.normalize_mask, normalized, value)
+        # Match SONIC: normalize with the prior statistics, then update them.
+        if self.training:
+            self._update(value)
+        return self.module(normalized)
 
 
 @dataclass
@@ -98,6 +204,9 @@ class PPOConfig:
 
     normalize_advantage: bool = True
     """Whether to normalize the advantage estimates."""
+
+    normalize_advantage_global: bool = False
+    """Normalize once over the complete rollout instead of per mini-batch."""
 
     log_std_init: float = 0.0
     """Initial value for the policy log standard deviation (log std)."""
@@ -243,6 +352,22 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         else:
             policy_mlp = policy_net
 
+        if getattr(self.config.policy, "normalize_input", False):
+            # SONIC-style running observation normalization for the actor.
+            # GaussianPolicyHead concatenates multi-key inputs before calling
+            # the base module, so the normalizer always receives one tensor.
+            policy_in_keys = self.config.policy.get_input_keys()
+            feature_dim = sum(
+                self.observation_feature_size(key) for key in policy_in_keys
+            )
+            policy_mlp = RunningMeanStdCatInputs(
+                policy_mlp,
+                feature_dim,
+                epsilon=self.config.policy.normalization_epsilon,
+                clip=self.config.policy.normalization_clip,
+                normalize_mask=self._input_normalize_mask(self.config.policy),
+            )
+
         net = GaussianPolicyHead(
             base=policy_mlp,
             action_dim=action_dim,
@@ -297,8 +422,41 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         # When multiple in_keys (concatenate_terms=False), TensorDictModule
         # passes each as a separate positional arg. MLP expects a single
         # tensor, so wrap it to concatenate first.
-        module = CatInputs(value_mlp) if len(in_keys) > 1 else value_mlp
+        if self.config.value_function.normalize_input:
+            feature_dim = sum(self.observation_feature_size(key) for key in in_keys)
+            module = RunningMeanStdCatInputs(
+                value_mlp,
+                feature_dim,
+                epsilon=self.config.value_function.normalization_epsilon,
+                clip=self.config.value_function.normalization_clip,
+                normalize_mask=self._input_normalize_mask(self.config.value_function),
+            )
+        else:
+            module = CatInputs(value_mlp) if len(in_keys) > 1 else value_mlp
         return ValueOperator(module=module, in_keys=in_keys)
+
+    def _input_normalize_mask(self, network_cfg) -> Tensor | None:
+        """Per-feature mask for running input normalization (True = normalize).
+
+        Keys listed in ``network_cfg.normalize_input_exclude_keys`` keep their
+        raw values (e.g. pretrained latent commands, sin/cos phases).
+        """
+        exclude = getattr(network_cfg, "normalize_input_exclude_keys", None)
+        if not exclude:
+            return None
+
+        def _as_key(key) -> tuple[str, ...]:
+            if isinstance(key, (list, tuple)):
+                return tuple(str(part) for part in key)
+            return (str(key),)
+
+        excluded_keys = {_as_key(key) for key in exclude}
+        mask_parts: list[Tensor] = []
+        for key in network_cfg.get_input_keys():
+            size = int(self.observation_feature_size(key))
+            keep = _as_key(key) not in excluded_keys
+            mask_parts.append(torch.full((size,), keep, dtype=torch.bool))
+        return torch.cat(mask_parts)
 
     def _construct_q_function(self) -> TensorDictModule:  # type: ignore[override]
         """PPO does not use a state-action value function explicitly.
@@ -355,7 +513,10 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
             loss_critic_type=loss_config.loss_critic_type,
             entropy_coeff=ppo_config.entropy_coeff,
             critic_coeff=ppo_config.critic_coeff,
-            normalize_advantage=ppo_config.normalize_advantage,
+            normalize_advantage=(
+                ppo_config.normalize_advantage
+                and not ppo_config.normalize_advantage_global
+            ),
             clip_value=ppo_config.clip_value,
         )
 
@@ -579,13 +740,43 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
 
     def pre_iteration_compute(self, rollout: TensorDict) -> TensorDict:
         """Turn one rollout into the replay-buffer view consumed by minibatch updates."""
-        with torch.no_grad():
+        # SONIC keeps the model in rollout/eval mode while it computes values and
+        # returns, then enables running-statistics updates only for PPO
+        # minibatches.  TorchRL evaluates current/next values through ``vmap``;
+        # mutating normalizer buffers from that vmapped forward is invalid too.
+        with torch.no_grad(), self._freeze_value_normalizer_updates():
             rollout = self.adv_module(rollout)
+            if (
+                self.config.ppo.normalize_advantage
+                and self.config.ppo.normalize_advantage_global
+            ):
+                advantage = rollout.get("advantage")
+                rollout.set(
+                    "advantage",
+                    _normalize_advantage_over_rollout(advantage),
+                )
             if getattr(self.config.compile, "compile", False):
                 rollout = rollout.clone()
 
         self.data_buffer.extend(rollout.reshape(-1))
         return rollout
+
+    @contextmanager
+    def _freeze_value_normalizer_updates(self):
+        """Normalize critic inputs without updating statistics during GAE."""
+        normalizers = [
+            module
+            for module in self.value_function.modules()
+            if isinstance(module, RunningMeanStdCatInputs)
+        ]
+        training_states = [module.training for module in normalizers]
+        try:
+            for module in normalizers:
+                module.eval()
+            yield
+        finally:
+            for module, training in zip(normalizers, training_states, strict=True):
+                module.train(training)
 
     @property
     def _required_loss_metrics(self) -> list[str]:
@@ -673,10 +864,15 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
             clip_epsilon = float(clip_attr.detach().item())
         else:
             clip_epsilon = float(metadata.base_clip_epsilon)
-        return {
+        metrics = {
             "train/lr": self.optim.param_groups[0]["lr"],
             "train/clip_epsilon": clip_epsilon,
         }
+        for group in self.optim.param_groups:
+            group_name = group.get("name")
+            if isinstance(group_name, str) and group_name:
+                metrics[f"train/{group_name}_lr"] = group["lr"]
+        return metrics
 
     def _build_timing_metrics(
         self, iteration: PPOIterationData, metadata: PPOTrainingMetadata
@@ -756,11 +952,9 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         self.collector.update_policy_weights_()
         self._refresh_progress_display(metadata, iteration)
 
-        if (
-            self._should_save_checkpoint(
-                frames_processed=metadata.frames_processed,
-                frames_in_iteration=iteration.frames,
-            )
+        if self._should_save_checkpoint(
+            frames_processed=metadata.frames_processed,
+            frames_in_iteration=iteration.frames,
         ):
             checkpoint_dir = self.log_dir / self.config.logger.save_path
             custom_save = getattr(self, "save", None)

--- a/rlopt/base_class.py
+++ b/rlopt/base_class.py
@@ -1303,7 +1303,16 @@ class BaseAlgorithm(Generic[CfgT], ABC):
         min_lr = getattr(schedule_cfg, "min_lr", None)
         max_lr = getattr(schedule_cfg, "max_lr", None)
 
-        lr = float(self.optim.param_groups[0]["lr"])
+        adaptive_groups = [
+            group
+            for group in self.optim.param_groups
+            if bool(group.get("adaptive_lr", True))
+        ]
+        if not adaptive_groups:
+            return
+
+        reference_group = adaptive_groups[0]
+        lr = float(reference_group["lr"])
         if kl_value > desired_kl * 2.0:
             lr /= factor
         elif kl_value < desired_kl / 2.0:
@@ -1311,13 +1320,23 @@ class BaseAlgorithm(Generic[CfgT], ABC):
         else:
             return
 
-        if min_lr is not None:
-            lr = max(lr, float(min_lr))
-        if max_lr is not None:
-            lr = min(lr, float(max_lr))
+        reference_min_lr = reference_group.get("lr_min", min_lr)
+        reference_max_lr = reference_group.get("lr_max", max_lr)
+        if reference_min_lr is not None:
+            lr = max(lr, float(reference_min_lr))
+        if reference_max_lr is not None:
+            lr = min(lr, float(reference_max_lr))
 
-        for group in self.optim.param_groups:
-            group["lr"] = lr
+        scale = lr / float(reference_group["lr"])
+        for group in adaptive_groups:
+            group_lr = float(group["lr"]) * scale
+            group_min_lr = group.get("lr_min", min_lr)
+            group_max_lr = group.get("lr_max", max_lr)
+            if group_min_lr is not None:
+                group_lr = max(group_lr, float(group_min_lr))
+            if group_max_lr is not None:
+                group_lr = min(group_lr, float(group_max_lr))
+            group["lr"] = group_lr
 
     @abstractmethod
     def _progress_summary_fields(self) -> tuple[tuple[str, str], ...]:

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -397,6 +397,23 @@ class NetworkConfig:
     activation_fn: str = "elu"
     """Activation function."""
 
+    normalize_input: bool = False
+    """Normalize the concatenated network input with running mean and variance."""
+
+    normalization_epsilon: float = 1.0e-5
+    """Numerical epsilon used by running input normalization."""
+
+    normalization_clip: float = 5.0
+    """Absolute clamp applied after running input normalization."""
+
+    normalize_input_exclude_keys: list[ObsKey] = field(default_factory=list)
+    """Input keys passed through running input normalization unchanged.
+
+    Use for inputs whose scale and geometry are already meaningful, such as
+    pretrained latent commands or sin/cos phase features, so running
+    statistics never distort them.
+    """
+
     kwargs: dict[str, Any] = field(default_factory=dict)
     """Additional keyword arguments for the network."""
 

--- a/rlopt/utils.py
+++ b/rlopt/utils.py
@@ -585,6 +585,8 @@ def get_activation_class(activation_name: str) -> type[torch.nn.Module]:
         "elu": torch.nn.ELU,
         "tanh": torch.nn.Tanh,
         "gelu": torch.nn.GELU,
+        "silu": torch.nn.SiLU,
+        "swish": torch.nn.SiLU,
     }
     return activation_map.get(activation_name, torch.nn.ELU)
 

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -91,7 +91,7 @@ def create_synthetic_expert_data(env, num_transitions: int = 100) -> TensorDict:
     )
 
 
-def _make_env_reward_only_ipmd_agent():
+def _make_env_reward_only_ipmd_agent(*, split_actor_critic_lr: bool = False):
     rlopt = _rlopt()
     cfg = rlopt.IPMDRLOptConfig()
     cfg.env.env_name = "Pendulum-v1"
@@ -113,9 +113,92 @@ def _make_env_reward_only_ipmd_agent():
     cfg.ipmd.reward_grad_penalty_coeff = 0.0
     cfg.ipmd.bc_coef = 0.0
     cfg.ipmd.diversity_bonus_coeff = 0.0
+    if split_actor_critic_lr:
+        cfg.ipmd.actor_learning_rate = 2.0e-5
+        cfg.ipmd.critic_learning_rate = 1.0e-3
+        cfg.optim.scheduler = "adaptive"
+        cfg.optim.min_lr = 1.0e-5
+        cfg.optim.max_lr = 2.0e-4
 
     env = rlopt.make_parallel_env(cfg)
     return rlopt.IPMD(env, cfg, logger=None), env
+
+
+def test_ipmd_split_actor_critic_learning_rates_and_adaptation():
+    agent, env = _make_env_reward_only_ipmd_agent(split_actor_critic_lr=True)
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        assert groups["actor"]["lr"] == pytest.approx(2.0e-5)
+        assert groups["critic"]["lr"] == pytest.approx(1.0e-3)
+
+        agent._maybe_adjust_lr(torch.tensor(1.0e-4), agent.config.optim)
+
+        assert groups["actor"]["lr"] == pytest.approx(3.0e-5)
+        assert groups["critic"]["lr"] == pytest.approx(1.0e-3)
+    finally:
+        env.close()
+
+
+def test_ipmd_split_learning_rates_must_be_configured_together():
+    cfg = _rlopt().IPMDRLOptConfig()
+    cfg.ipmd.actor_learning_rate = 2.0e-5
+    with pytest.raises(ValueError, match="must be configured together"):
+        cfg.ipmd.validate()
+
+
+def test_silu_activation_is_available():
+    from rlopt.utils import get_activation_class
+
+    assert get_activation_class("silu") is torch.nn.SiLU
+    assert get_activation_class("swish") is torch.nn.SiLU
+
+
+def test_sonic_running_mean_std_normalizes_concatenated_critic_input():
+    from rlopt.agent.ppo.ppo import RunningMeanStdCatInputs
+
+    normalizer = RunningMeanStdCatInputs(
+        torch.nn.Identity(),
+        feature_dim=2,
+        epsilon=1.0e-5,
+        clip=5.0,
+    )
+    first = torch.tensor([[1.0], [3.0]])
+    second = torch.tensor([[3.0], [7.0]])
+    output = normalizer(first, second)
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[1.0, 3.0], [3.0, 5.0]]),
+        atol=6.0e-5,
+        rtol=0.0,
+    )
+    assert normalizer.count.item() == pytest.approx(3.0)
+
+    running_mean = normalizer.running_mean.clone()
+    running_var = normalizer.running_var.clone()
+    normalizer.eval()
+    normalized = normalizer(torch.tensor([[2.0]]), torch.tensor([[5.0]]))
+    torch.testing.assert_close(
+        normalized,
+        (torch.tensor([[2.0, 5.0]]) - running_mean) / torch.sqrt(running_var + 1.0e-5),
+    )
+    torch.testing.assert_close(normalizer.running_mean, running_mean)
+    torch.testing.assert_close(normalizer.running_var, running_var)
+
+    vmapped = torch.vmap(normalizer)(torch.tensor([[[2.0, 5.0]], [[3.0, 7.0]]]))
+    assert vmapped.shape == (2, 1, 2)
+    torch.testing.assert_close(normalizer.running_mean, running_mean)
+    torch.testing.assert_close(normalizer.running_var, running_var)
+
+
+def test_sonic_advantage_normalization_uses_the_complete_rollout():
+    from rlopt.agent.ppo.ppo import _normalize_advantage_over_rollout
+
+    advantage = torch.arange(6, dtype=torch.float32).reshape(2, 3, 1)
+    normalized = _normalize_advantage_over_rollout(advantage)
+
+    torch.testing.assert_close(normalized.mean(dim=(0, 1)), torch.zeros(1))
+    torch.testing.assert_close(normalized.std(dim=(0, 1)), torch.ones(1))
 
 
 def _make_bilinear_offline_cfg():
@@ -1444,6 +1527,68 @@ def test_ipmd_rollout_bc_uses_live_policy_observations() -> None:
         assert torch.isfinite(warmup_loss[key])
         assert torch.isfinite(normal_loss[key])
     assert "loss_bc" not in warmup_loss
+
+
+def test_ipmd_rollout_bc_mse_supervises_policy_mean() -> None:
+    """MSE rollout BC should be independent of the policy exploration std."""
+    rlopt = _rlopt()
+    cfg = rlopt.IPMDRLOptConfig()
+    cfg.env.env_name = "Pendulum-v1"
+    cfg.env.device = "cpu"
+    cfg.device = "cpu"
+    cfg.collector.frames_per_batch = 4
+    cfg.collector.total_frames = 4
+    cfg.replay_buffer.size = 64
+    cfg.loss.mini_batch_size = 4
+    cfg.compile.compile = False
+    _apply_nonlatent_obs_input_keys(cfg)
+    cfg.ipmd.rollout_bc_coef = 0.01
+    cfg.ipmd.rollout_bc_loss_type = "mse"
+    cfg.ipmd.rollout_bc_action_key = ["policy_supervision", "expert_action"]
+
+    env = rlopt.make_parallel_env(cfg)
+    spec = env.observation_spec.clone()
+    spec.set(("policy_supervision", "expert_action"), env.action_spec.clone())
+    env.observation_spec = spec
+    agent = rlopt.IPMD(env, cfg, logger=None)
+
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    act_dim = env.action_spec.shape[-1]
+    batch = TensorDict(
+        {
+            "observation": torch.randn(4, obs_dim),
+            ("policy_supervision", "expert_action"): torch.randn(4, act_dim),
+            "action": torch.randn(4, act_dim),
+            "action_log_prob": torch.zeros(4),
+            ("next", "observation"): torch.randn(4, obs_dim),
+            ("next", "reward"): torch.randn(4, 1),
+            ("next", "done"): torch.zeros(4, 1, dtype=torch.bool),
+            ("next", "terminated"): torch.zeros(4, 1, dtype=torch.bool),
+            ("next", "truncated"): torch.zeros(4, 1, dtype=torch.bool),
+        },
+        batch_size=[4],
+    )
+    with torch.no_grad():
+        batch = agent.adv_module(batch)
+    loss, _ = agent.update(
+        batch,
+        0,
+        TensorDict({}, batch_size=[4]),
+        torch.tensor(0.0),
+    )
+
+    assert torch.isfinite(loss["rollout_bc_mse"])
+    assert torch.allclose(
+        loss["loss_rollout_bc"],
+        0.01 * loss["rollout_bc_mse"],
+    )
+
+
+def test_ipmd_rollout_bc_rejects_unknown_loss_type() -> None:
+    cfg = _rlopt().IPMDRLOptConfig()
+    cfg.ipmd.rollout_bc_loss_type = "cosine"
+    with pytest.raises(ValueError, match="rollout_bc_loss_type"):
+        cfg.ipmd.validate()
 
 
 def test_ipmd_rollout_bc_label_cannot_be_a_model_input() -> None:


### PR DESCRIPTION
- Apply global per-rollout advantage normalization on the IPMD path when ppo.normalize_advantage_global is set; previously the IPMD override of pre_iteration_compute skipped it entirely, so SONIC-configured runs trained on raw unnormalized advantages.
- Honor policy.normalize_input with the same running mean/std wrapper the critic uses, and add normalize_input_exclude_keys so pretrained latent commands (skill code + sin/cos phase) pass through unnormalized.
- Split actor/critic optimizer param groups with an adaptive-KL-scheduled actor learning rate bounded by optim.min_lr/max_lr.
- Add SiLU to the activation registry and running-normalizer freeze during GAE.