### PR TITLE
v2 migration: env-interface boundary, IPMD teacher/student, KL-per-iteration, SONIC FSQ, profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,8 @@ isort.required-imports = ["from __future__ import annotations"]
 "tests/**" = ["T20", "PLC0415"]
 
 [tool.pyrefly.errors]
-index-error = false
+bad-index = false
 
 [tool.pyrefly]
 disable-type-errors-in-ide = true
+python-interpreter-path = "../.pixi/envs/default/bin/python"

--- a/rlopt/agent/__init__.py
+++ b/rlopt/agent/__init__.py
@@ -22,9 +22,12 @@ from rlopt.agent.hl_skill_encoder import (
 )
 from rlopt.agent.ipmd import (
     IPMD,
+    IPMDL2T,
     IPMDSR,
     IPMDBilinear,
     IPMDBilinearRLOptConfig,
+    IPMDL2TConfig,
+    IPMDL2TRLOptConfig,
     IPMDRLOptConfig,
     IPMDSRRLOptConfig,
 )
@@ -45,6 +48,7 @@ __all__ = [
     "ASE",
     "GAIL",
     "IPMD",
+    "IPMDL2T",
     "IPMDSR",
     "PPO",
     "SAC",
@@ -68,6 +72,8 @@ __all__ = [
     "HighLevelSkillEncoder",
     "IPMDBilinear",
     "IPMDBilinearRLOptConfig",
+    "IPMDL2TConfig",
+    "IPMDL2TRLOptConfig",
     "IPMDRLOptConfig",
     "IPMDSRRLOptConfig",
     "PPORLOptConfig",

--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -246,6 +246,11 @@ class HighLevelSkillDiffSRConfig:
     gumbel_tau_anneal_iters: int = 2000
     gumbel_hard: bool = True
     fsq_levels: tuple[int, ...] = (8, 8, 8, 5, 5)
+    # SONIC-matched token space: 64 dims x 32 levels ~= 320 bits per command,
+    # i.e. gear_sonic's tokens of shape (2, 32) at num_fsq_levels=32. Used only
+    # by latent_mode="sonic_fsq", which publishes the quantizer output directly
+    # and therefore requires z_dim == len(sonic_fsq_levels).
+    sonic_fsq_levels: tuple[int, ...] = (32,) * 64
     vq_codebook_size: int = 512
     vq_ema_decay: float = 0.99
     vq_dead_code_reset_iters: int = 0
@@ -346,6 +351,25 @@ class HighLevelSkillDiffSRConfig:
         if self.latent_mode == "fsq" and any(level < 2 for level in self.fsq_levels):
             msg = f"fsq_levels must each be >= 2, got {self.fsq_levels!r}."
             raise ValueError(msg)
+        self.sonic_fsq_levels = tuple(
+            _require_positive_int("sonic_fsq_levels", level)
+            for level in self.sonic_fsq_levels
+        )
+        if self.latent_mode == "sonic_fsq":
+            if any(level < 2 for level in self.sonic_fsq_levels):
+                msg = (
+                    "sonic_fsq_levels must each be >= 2, got "
+                    f"{self.sonic_fsq_levels!r}."
+                )
+                raise ValueError(msg)
+            if self.z_dim != len(self.sonic_fsq_levels):
+                msg = (
+                    "latent_mode='sonic_fsq' publishes the quantizer output as the "
+                    "command, so z_dim must equal len(sonic_fsq_levels): "
+                    f"z_dim={self.z_dim}, "
+                    f"len(sonic_fsq_levels)={len(self.sonic_fsq_levels)}."
+                )
+                raise ValueError(msg)
         self.vq_codebook_size = _require_positive_int(
             "vq_codebook_size", self.vq_codebook_size
         )
@@ -424,6 +448,7 @@ class HighLevelSkillDiffSRConfig:
             gumbel_tau_anneal_iters=self.gumbel_tau_anneal_iters,
             gumbel_hard=self.gumbel_hard,
             fsq_levels=tuple(self.fsq_levels),
+            sonic_fsq_levels=tuple(self.sonic_fsq_levels),
             vq_codebook_size=self.vq_codebook_size,
             vq_ema_decay=self.vq_ema_decay,
             vq_dead_code_reset_iters=self.vq_dead_code_reset_iters,
@@ -442,6 +467,7 @@ class HighLevelSkillDiffSRConfig:
             "diffsr_g_hidden_dims",
             "diffsr_mu_hidden_dims",
             "fsq_levels",
+            "sonic_fsq_levels",
             "commander_hidden_dims",
         }
         for key in tuple_fields:

--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -132,6 +132,8 @@ def _build_diffsr(
         feature_dim=config.diffsr_feature_dim,
         embed_dim=config.diffsr_embed_dim,
         g_hidden_dims=config.diffsr_g_hidden_dims,
+        f_hidden_dims=config.diffsr_f_hidden_dims,
+        phi_parameterization=config.diffsr_phi_parameterization,
         mu_hidden_dims=config.diffsr_mu_hidden_dims,
         num_noises=config.diffsr_num_noises,
         use_ema_for_policy=False,
@@ -223,6 +225,13 @@ class HighLevelSkillDiffSRConfig:
     z_dim: int = 256
     diffsr_feature_dim: int = 128
     diffsr_embed_dim: int = 512
+    diffsr_phi_parameterization: str = "concat"
+    """phi(s, z) parameterization forwarded to the SR module.
+
+    "concat" is the simple-concat path; "bilinear" restores the legacy matrix
+    form g(z)^T F(s). Both are implemented by `BilinearSR.forward_phi`; this
+    field is what lets the pretrain entrypoint select between them, and its
+    default matches `BilinearSR`'s so omitting it changes nothing."""
     batch_size: int = 8192
     num_updates: int = 2000
     log_interval: int = 100

--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -548,19 +548,19 @@ class FrozenHighLevelSkillCommandSampler:
             else self.latent_steps_max
         )
         self.device = _resolve_device(device, env)
-        from rlopt.utils import require_env_method
+        from rlopt.env_interface import require_imitation_interface, supports
+        from rlopt.env_interface import resolve_imitation_interface
 
-        self._current_macro_sampler = require_env_method(
+        self._env_interface = resolve_imitation_interface(env)
+        self._current_macro_sampler = require_imitation_interface(
             env,
             "current_expert_macro_transition_batch",
-            purpose=(
-                "command_source='hl_skill' requires the environment to expose "
-                "current_expert_macro_transition_batch(...)"
-            ),
+            purpose="command_source='hl_skill' requires it but",
         )
-        self._offline_macro_sampler = discover_env_method(
-            env,
-            "sample_expert_macro_transition_batch",
+        self._offline_macro_sampler = (
+            self._env_interface.sample_expert_macro_transition_batch
+            if supports(self._env_interface, "sample_expert_macro_transition_batch")
+            else None
         )
         if self.finetune_enabled and self._offline_macro_sampler is None:
             msg = (
@@ -1179,10 +1179,13 @@ class HighLevelSkillDiffSRTrainer:
         *,
         split: str | None,
     ) -> TensorDictBase:
-        sampler = getattr(self.env, "sample_expert_macro_transition_batch", None)
-        if not callable(sampler):
-            msg = "env must expose sample_expert_macro_transition_batch(...)."
-            raise ValueError(msg)
+        from rlopt.env_interface import require_imitation_interface
+
+        sampler = require_imitation_interface(
+            self.env,
+            "sample_expert_macro_transition_batch",
+            purpose="Offline skill-encoder training requires it but",
+        )
         return sampler(
             batch_size=int(batch_size),
             horizon_steps=int(self.config.horizon_steps),
@@ -1207,9 +1210,12 @@ class HighLevelSkillDiffSRTrainer:
         )
 
     def _resolve_feature_slices(self) -> dict[str, tuple[int, int]]:
-        provider = getattr(self.env, "expert_macro_feature_slices", None)
-        if not callable(provider):
+        from rlopt.env_interface import resolve_imitation_interface, supports
+
+        interface = resolve_imitation_interface(self.env)
+        if not supports(interface, "expert_macro_feature_slices"):
             return {}
+        provider = interface.expert_macro_feature_slices
         raw_slices = provider(horizon_steps=int(self.config.horizon_steps))
         if raw_slices is None:
             return {}

--- a/rlopt/agent/hl_skill_diffsr.py
+++ b/rlopt/agent/hl_skill_diffsr.py
@@ -548,16 +548,16 @@ class FrozenHighLevelSkillCommandSampler:
             else self.latent_steps_max
         )
         self.device = _resolve_device(device, env)
-        self._current_macro_sampler = discover_env_method(
+        from rlopt.utils import require_env_method
+
+        self._current_macro_sampler = require_env_method(
             env,
             "current_expert_macro_transition_batch",
-        )
-        if self._current_macro_sampler is None:
-            msg = (
+            purpose=(
                 "command_source='hl_skill' requires the environment to expose "
-                "current_expert_macro_transition_batch(...)."
-            )
-            raise ValueError(msg)
+                "current_expert_macro_transition_batch(...)"
+            ),
+        )
         self._offline_macro_sampler = discover_env_method(
             env,
             "sample_expert_macro_transition_batch",

--- a/rlopt/agent/hl_skill_encoder.py
+++ b/rlopt/agent/hl_skill_encoder.py
@@ -24,6 +24,7 @@ LATENT_MODES = (
     "gumbel_multicat",
     "gumbel",
     "fsq",
+    "sonic_fsq",
     "vq",
 )
 
@@ -550,6 +551,63 @@ class FSQSkillEncoder(_DiscreteSkillEncoder):
         return z_q, code, z_e.new_zeros(()), {}
 
 
+class SONICFSQSkillEncoder(_DiscreteSkillEncoder):
+    """SONIC-motivated FSQ bottleneck: the quantizer output *is* the command.
+
+    Two differences from :class:`FSQSkillEncoder`, both required for the
+    planner -> tracker interface to actually be quantized rather than merely
+    trained through a quantizer:
+
+    1. **Normalized codes.** Emits ``round(bound(z)) / (L // 2)``, so values land
+       on the lattice in ``[-1, 1]``. This matches the released SONIC token
+       space: every entry of ``gear_sonic``'s ``LATENT_INITIAL_MOTION_TOKEN`` is
+       an exact multiple of ``1/16 = 1/(32 // 2)``.
+    2. **No projection before the command boundary.** :class:`FSQSkillEncoder`
+       applies ``code_to_latent = nn.Linear(code_dim, z_dim)`` inside
+       ``_latent``, so the published command is a ``z_dim`` continuous vector and
+       every point in R^z_dim is admissible -- the interface is not quantized,
+       only the training was. Here ``code_to_latent`` is the identity and
+       ``z_dim == len(levels)``, so the tracker observes the lattice values
+       directly and its own first layer plays the role of SONIC's ``g1_dyn``
+       input projection.
+
+    :class:`FSQQuantizer` is reused unmodified: dividing its straight-through
+    output by a constant preserves the estimator -- the forward value becomes
+    ``rounded / half`` and the gradient is scaled by ``1 / half``.
+    """
+
+    def __init__(self, *, levels: tuple[int, ...] = (32,) * 64, **base) -> None:
+        z_dim = int(base["z_dim"])
+        if z_dim != len(levels):
+            msg = (
+                "sonic_fsq publishes the quantizer output directly, so z_dim must "
+                f"equal the number of FSQ dimensions: z_dim={z_dim}, "
+                f"len(levels)={len(levels)}."
+            )
+            raise ValueError(msg)
+        super().__init__(raw_dim=len(levels), **base)
+        self.fsq = FSQQuantizer(levels)
+        # Same pooled-code convention as FSQSkillEncoder: a flat code index only
+        # exists when the level product fits int64 (SONIC's 64 x 32 is 2^320).
+        self.num_codes = (
+            self.fsq.codebook_size
+            if self.fsq.flat_code_supported
+            else max(int(level) for level in levels)
+        )
+        # The command boundary sits at the quantizer output -- no learned map.
+        self.code_to_latent = nn.Identity()
+        self.register_buffer(
+            "_half_levels",
+            torch.tensor(
+                [max(int(level) // 2, 1) for level in levels], dtype=torch.float32
+            ),
+        )
+
+    def _quantize(self, z_e, **_):
+        z_q, code = self.fsq(z_e)
+        return z_q / self._half_levels.to(z_q.dtype), code, z_e.new_zeros(()), {}
+
+
 # --------------------------------------------------------------------------- #
 # Spec + factory.
 # --------------------------------------------------------------------------- #
@@ -568,6 +626,9 @@ class SkillLatentSpec:
     gumbel_tau_anneal_iters: int = 2000
     gumbel_hard: bool = True
     fsq_levels: tuple[int, ...] = (8, 8, 8, 5, 5)
+    # SONIC-matched token space: 64 dims x 32 levels ~= 320 bits per command,
+    # i.e. gear_sonic's tokens of shape (2, 32) at num_fsq_levels=32.
+    sonic_fsq_levels: tuple[int, ...] = (32,) * 64
     vq_codebook_size: int = 512
     vq_ema_decay: float = 0.99
     vq_dead_code_reset_iters: int = 0
@@ -623,6 +684,8 @@ def build_skill_encoder(
         )
     if mode == "fsq":
         return FSQSkillEncoder(levels=tuple(spec.fsq_levels), **base)
+    if mode == "sonic_fsq":
+        return SONICFSQSkillEncoder(levels=tuple(spec.sonic_fsq_levels), **base)
     if mode == "vq":
         return VQSkillEncoder(
             codebook_size=spec.vq_codebook_size,

--- a/rlopt/agent/hl_skill_encoder.py
+++ b/rlopt/agent/hl_skill_encoder.py
@@ -587,6 +587,12 @@ class FSQSkillEncoder(_DiscreteSkillEncoder):
             if self.fsq.flat_code_supported
             else max(int(level) for level in levels)
         )
+        # `perplexity` is a flat-codebook statistic. Without a flat index the
+        # codes are per-dimension level indices, so bincounting them pools
+        # every dimension into one histogram and the number means nothing --
+        # the same reason MultiCategoricalSkillEncoder opts out. SONIC's
+        # 64 x 32 lattice is 2^320 and always lands here.
+        self.report_flat_code_metrics = bool(self.fsq.flat_code_supported)
         self.code_to_latent = nn.Linear(self.fsq.code_dim, base["z_dim"])
 
     def _quantize(self, z_e, **_):
@@ -637,6 +643,12 @@ class SONICFSQSkillEncoder(_DiscreteSkillEncoder):
             if self.fsq.flat_code_supported
             else max(int(level) for level in levels)
         )
+        # `perplexity` is a flat-codebook statistic. Without a flat index the
+        # codes are per-dimension level indices, so bincounting them pools
+        # every dimension into one histogram and the number means nothing --
+        # the same reason MultiCategoricalSkillEncoder opts out. SONIC's
+        # 64 x 32 lattice is 2^320 and always lands here.
+        self.report_flat_code_metrics = bool(self.fsq.flat_code_supported)
         # The command boundary sits at the quantizer output -- no learned map.
         self.code_to_latent = nn.Identity()
         self.register_buffer(

--- a/rlopt/agent/imitation/latent_commands.py
+++ b/rlopt/agent/imitation/latent_commands.py
@@ -164,7 +164,17 @@ class LatentCommandController:
             latent_steps_max=latent_steps_max,
         )
 
-        self._env_latent_setter = discover_env_method(env, "set_agent_latent_command")
+        # The agent publishes its latent through the environment's imitation
+        # interface; `discover_env_method` stays in the signature for the other
+        # discoveries its callers inject.
+        from rlopt.env_interface import resolve_imitation_interface, supports
+
+        interface = resolve_imitation_interface(env)
+        self._env_latent_setter = (
+            interface.publish_actor_command
+            if supports(interface, "publish_actor_command")
+            else None
+        )
 
         available_keys = set(env.observation_spec.keys(True))
         if self.latent_key not in available_keys:

--- a/rlopt/agent/imitation/latent_learning.py
+++ b/rlopt/agent/imitation/latent_learning.py
@@ -1527,22 +1527,33 @@ class FSQQuantizer(nn.Module):
             raise ValueError(msg)
         levels_i = torch.tensor([int(level) for level in levels], dtype=torch.long)
         levels_t = levels_i.to(torch.float32)
+        # Exact Python-int product: torch prod/cumprod silently overflow for
+        # SONIC's 64 coordinates x 32 levels (2**320).
+        self._codebook_size = math.prod(int(level) for level in levels)
+        self.flat_code_supported = self._codebook_size <= (1 << 62)
+        basis = torch.ones(levels_i.numel(), dtype=torch.long)
+        if self.flat_code_supported:
+            basis = torch.cumprod(
+                torch.cat([torch.ones(1, dtype=torch.long), levels_i[:-1]]),
+                dim=0,
+            )
         # Half range per dim: integer indices range over [-half, half] (with one extra
         # for even L).  We follow the canonical implementation.
         self.register_buffer("levels", levels_t)
         self.register_buffer("_levels_i", levels_i)
-        self.register_buffer(
-            "_basis",
-            torch.cumprod(
-                torch.cat([torch.ones(1), levels_t[:-1]]),
-                dim=0,
-            ).to(torch.long),
-        )
+        self.register_buffer("_basis", basis)
         self.code_dim = len(levels)
 
     @property
     def codebook_size(self) -> int:
-        return int(self.levels.prod().item())
+        return self._codebook_size
+
+    @property
+    def usage_vocab_size(self) -> int:
+        """Vocabulary used by pooled code-usage diagnostics."""
+        if self.flat_code_supported:
+            return self._codebook_size
+        return int(self._levels_i.max().item())
 
     def _bound(self, z: Tensor) -> Tensor:
         # Squash to [-1, 1] with extra slack so the rounded grid stays inside.
@@ -1565,15 +1576,29 @@ class FSQQuantizer(nn.Module):
         zhat = rounded.to(torch.long) + levels_i // 2
         zhat = zhat.clamp(min=0)
         zhat = torch.minimum(zhat, levels_i - 1)
-        code = (zhat * self._basis.to(zhat.device)).sum(dim=-1)
+        if self.flat_code_supported:
+            code = (zhat * self._basis.to(zhat.device)).sum(dim=-1)
+        else:
+            # A scalar mixed-radix index cannot fit int64. Preserve the exact
+            # per-coordinate indices, which is also SONIC's usable token form.
+            code = zhat
         return z_q, code, bounded
 
     def indices_to_codes(self, code: Tensor) -> Tensor:
-        """Convert mixed-radix token IDs back to FSQ vectors."""
+        """Convert flat or per-coordinate FSQ indices back to quantized values."""
         code = code.to(device=self.levels.device, dtype=torch.long)
         levels_i = self._levels_i.to(code.device)
-        basis = self._basis.to(code.device)
-        indices = (code.unsqueeze(-1) // basis) % levels_i
+        if self.flat_code_supported:
+            basis = self._basis.to(code.device)
+            indices = (code.unsqueeze(-1) // basis) % levels_i
+        else:
+            if code.shape[-1] != self.code_dim:
+                msg = (
+                    "Large FSQ spaces require per-coordinate indices with final "
+                    f"dimension {self.code_dim}, got {tuple(code.shape)}."
+                )
+                raise ValueError(msg)
+            indices = code
         return (indices - levels_i // 2).to(self.levels.dtype)
 
 
@@ -1948,6 +1973,9 @@ class PatchVQVAELatentLearner(BaseLatentLearner):
         if kind == "fsq":
             assert self.fsq is not None
             z_q, code, _ = self.fsq(z_e)
+            if bool(self._config().fsq_normalize_codes):
+                half = (self.fsq.levels // 2).clamp(min=1).to(z_q.dtype)
+                z_q = z_q / half
             out["z_q"] = z_q
             out["code"] = code
             out["aux_loss"] = torch.zeros((), device=z_e.device)
@@ -2261,8 +2289,8 @@ class PatchVQVAELatentLearner(BaseLatentLearner):
         # Code-usage diagnostics + dead-code revival.
         with torch.no_grad():
             code_flat = code.reshape(-1)
-            codebook_size = self._codebook_size()
-            usage_hist = torch.bincount(code_flat, minlength=codebook_size).float()
+            usage_vocab_size = self._code_usage_vocab_size()
+            usage_hist = torch.bincount(code_flat, minlength=usage_vocab_size).float()
             usage_prob = usage_hist / usage_hist.sum().clamp(min=1.0)
             perplexity = torch.exp(
                 -(usage_prob * (usage_prob.clamp(min=1e-12)).log()).sum()
@@ -2297,6 +2325,12 @@ class PatchVQVAELatentLearner(BaseLatentLearner):
         if self._quantizer_kind() == "gumbel":
             metrics["ipmd/vqvae_gumbel_tau"] = float(self._current_tau())
         return metrics
+
+    def _code_usage_vocab_size(self) -> int:
+        if self._quantizer_kind() == "fsq":
+            assert self.fsq is not None
+            return self.fsq.usage_vocab_size
+        return self._codebook_size()
 
     def _codebook_size(self) -> int:
         kind = self._quantizer_kind()
@@ -2409,6 +2443,9 @@ class PerStepVQSequenceLatentLearner(PatchVQVAELatentLearner):
         if kind == "fsq":
             assert self.fsq is not None
             z_q = self.fsq.indices_to_codes(code)
+            if bool(self._config().fsq_normalize_codes):
+                half = (self.fsq.levels // 2).clamp(min=1).to(z_q.dtype)
+                z_q = z_q / half
         elif kind == "vq_ema":
             assert self.vq is not None
             z_q = F.embedding(code.to(torch.long), self.vq.embedding)

--- a/rlopt/agent/ipmd/__init__.py
+++ b/rlopt/agent/ipmd/__init__.py
@@ -4,6 +4,10 @@ from rlopt.agent.ipmd.ipmd import (
     IPMD,
     IPMDRLOptConfig,
 )
+from rlopt.agent.ipmd.ipmd_bilinear import (
+    IPMDBilinear,
+    IPMDBilinearRLOptConfig,
+)
 
 # from rlopt.agent.ipmd.ipmd import IPMD, IPMDRLOptConfig
 from rlopt.agent.ipmd.ipmd_diffsr import (
@@ -12,22 +16,26 @@ from rlopt.agent.ipmd.ipmd_diffsr import (
 from rlopt.agent.ipmd.ipmd_diffsr import (
     IPMDDiffSRConfig as DiffSRRLOptConfig,
 )
+from rlopt.agent.ipmd.ipmd_l2t import (
+    IPMDL2T,
+    IPMDL2TConfig,
+    IPMDL2TRLOptConfig,
+)
 from rlopt.agent.ipmd.ipmd_sr import (
     IPMDSR,
     IPMDSRRLOptConfig,
 )
-from rlopt.agent.ipmd.ipmd_bilinear import (
-    IPMDBilinear,
-    IPMDBilinearRLOptConfig,
-)
 
 __all__ = [
     "IPMD",
+    "IPMDL2T",
     "IPMDSR",
-    "IPMDBilinear",
     "DiffSR",
     "DiffSRRLOptConfig",
+    "IPMDBilinear",
+    "IPMDBilinearRLOptConfig",
+    "IPMDL2TConfig",
+    "IPMDL2TRLOptConfig",
     "IPMDRLOptConfig",
     "IPMDSRRLOptConfig",
-    "IPMDBilinearRLOptConfig",
 ]

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -183,6 +183,13 @@ class IPMDLatentLearningConfig:
     fsq_levels: list[int] = field(default_factory=lambda: [8, 8, 8, 5, 5])
     """Per-dimension level counts for FSQ. Effective codebook size = prod(levels)."""
 
+    fsq_normalize_codes: bool = False
+    """Divide FSQ lattice values by ``levels // 2`` before publication.
+
+    This preserves legacy reconstruction arms by default. Enable it for SONIC,
+    whose public token values live on a normalized lattice in [-1, 1].
+    """
+
     codebook_size: int = 512
     """Codebook size for ``vq_ema`` and ``gumbel`` quantizers."""
 

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -3249,69 +3249,88 @@ class IPMD(PPO):
 
         with timeit("training"):
             rollout_flat = iteration.rollout.reshape(-1)
-            if self._latent_learner is not None:
-                learner_metrics = self._latent_learner.update(rollout_flat)
-                if learner_metrics:
-                    iteration.metrics.update(
-                        {f"train/{k}": v for k, v in learner_metrics.items()}
-                    )
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/latent_update"
+            ):
+                if self._latent_learner is not None:
+                    learner_metrics = self._latent_learner.update(rollout_flat)
+                    if learner_metrics:
+                        iteration.metrics.update(
+                            {f"train/{k}": v for k, v in learner_metrics.items()}
+                        )
 
-            reward_metrics = self._run_pre_policy_reward_updates(
-                rollout_flat,
-                metadata,
-            )
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/reward_updates"
+            ):
+                reward_metrics = self._run_pre_policy_reward_updates(
+                    rollout_flat,
+                    metadata,
+                )
             iteration.metrics.update(
                 {f"train/{key}": value.item() for key, value in reward_metrics.items()}
             )
-            iteration.metrics.update(self._prepare_rollout_rewards(iteration.rollout))
-            iteration.rollout = self.pre_iteration_compute(iteration.rollout)
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/reward_assignment"
+            ):
+                iteration.metrics.update(
+                    self._prepare_rollout_rewards(iteration.rollout)
+                )
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/advantage_and_buffer"
+            ):
+                iteration.rollout = self.pre_iteration_compute(iteration.rollout)
 
-            for epoch_idx in range(metadata.epochs_per_rollout):
-                for batch_idx, batch in enumerate(self.data_buffer):
-                    kl_context = None
-                    if (self.config.optim.scheduler or "").lower() == "adaptive":
-                        kl_context = self._prepare_kl_context(
-                            batch, metadata.policy_operator
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/policy_updates"
+            ):
+                for epoch_idx in range(metadata.epochs_per_rollout):
+                    for batch_idx, batch in enumerate(self.data_buffer):
+                        kl_context = None
+                        if (self.config.optim.scheduler or "").lower() == "adaptive":
+                            kl_context = self._prepare_kl_context(
+                                batch, metadata.policy_operator
+                            )
+
+                        needs_expert_batch = bool(self._bc_coeff > 0.0)
+                        if needs_expert_batch:
+                            expert_batch, has_expert = self._expert_batch_for_update(
+                                batch
+                            )
+                        else:
+                            expert_batch = TensorDict(
+                                {},
+                                batch_size=batch.batch_size,
+                                device=self.device,
+                            )
+                            has_expert = torch.zeros(
+                                (),
+                                device=self.device,
+                                dtype=torch.float32,
+                            )
+                        with timeit("training/update"):
+                            loss, metadata.updates_completed = self.update(
+                                batch,
+                                metadata.updates_completed,
+                                expert_batch,
+                                has_expert,
+                            )
+
+                        if self.lr_scheduler and self.lr_scheduler_step == "update":
+                            self.lr_scheduler.step()
+                        if kl_context is not None:
+                            kl_approx = self._compute_kl_after_update(
+                                kl_context, metadata.policy_operator
+                            )
+                            if kl_approx is not None:
+                                loss.set("kl_approx", kl_approx.detach())
+                                self._maybe_adjust_lr(kl_approx, self.config.optim)
+
+                        losses[epoch_idx, batch_idx] = (
+                            self._select_reported_loss_metrics(loss)
                         )
 
-                    needs_expert_batch = bool(self._bc_coeff > 0.0)
-                    if needs_expert_batch:
-                        expert_batch, has_expert = self._expert_batch_for_update(batch)
-                    else:
-                        expert_batch = TensorDict(
-                            {},
-                            batch_size=batch.batch_size,
-                            device=self.device,
-                        )
-                        has_expert = torch.zeros(
-                            (),
-                            device=self.device,
-                            dtype=torch.float32,
-                        )
-                    with timeit("training/update"):
-                        loss, metadata.updates_completed = self.update(
-                            batch,
-                            metadata.updates_completed,
-                            expert_batch,
-                            has_expert,
-                        )
-
-                    if self.lr_scheduler and self.lr_scheduler_step == "update":
+                    if self.lr_scheduler and self.lr_scheduler_step == "epoch":
                         self.lr_scheduler.step()
-                    if kl_context is not None:
-                        kl_approx = self._compute_kl_after_update(
-                            kl_context, metadata.policy_operator
-                        )
-                        if kl_approx is not None:
-                            loss.set("kl_approx", kl_approx.detach())
-                            self._maybe_adjust_lr(kl_approx, self.config.optim)
-
-                    losses[epoch_idx, batch_idx] = self._select_reported_loss_metrics(
-                        loss
-                    )
-
-                if self.lr_scheduler and self.lr_scheduler_step == "epoch":
-                    self.lr_scheduler.step()
 
         iteration.learn_time = time.perf_counter() - learn_start
         losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -2835,6 +2835,40 @@ class IPMD(PPO):
                 step=metadata.frames_processed,
             )
 
+    def _checkpoint_policy_state_dict(self) -> Mapping[str, Any]:
+        """Return the policy payload stored under ``policy_state_dict``."""
+        return self.policy.state_dict() if self.policy else {}
+
+    def _extra_checkpoint_state_dict(self) -> dict[str, Any]:
+        """Return algorithm-specific additions to an IPMD checkpoint."""
+        return {}
+
+    def _load_checkpoint_policy_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+        """Restore the primary IPMD policy from one checkpoint."""
+        if self.policy and "policy_state_dict" in checkpoint:
+            self.policy.load_state_dict(checkpoint["policy_state_dict"])
+
+    def _restore_training_state_from_checkpoint(
+        self, checkpoint: Mapping[str, Any]
+    ) -> bool:
+        """Return whether auxiliary training state should be restored.
+
+        An ordinary IPMD agent may consume the student-primary policy from an
+        IPMD-L2T checkpoint for deployment. Its optimizer and privileged value
+        network do not have the same layout, so those states are intentionally
+        skipped. IPMD-L2T overrides this hook for exact training resume.
+        """
+        metadata = checkpoint.get("checkpoint_metadata")
+        return not (
+            isinstance(metadata, Mapping)
+            and metadata.get("algorithm") == "IPMD_L2T"
+            and metadata.get("primary_policy_role") == "student"
+        )
+
+    def _load_extra_checkpoint_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+        """Restore algorithm-specific additions from an IPMD checkpoint."""
+        del checkpoint
+
     def save_model(
         self, path: str | Path | None = None, step: int | None = None
     ) -> None:
@@ -2858,8 +2892,8 @@ class IPMD(PPO):
             target_path = target_base / "model.pt"
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        data_to_save: dict[str, torch.Tensor | dict] = {
-            "policy_state_dict": (self.policy.state_dict() if self.policy else {}),
+        data_to_save: dict[str, Any] = {
+            "policy_state_dict": self._checkpoint_policy_state_dict(),
             "optimizer_state_dict": self.optim.state_dict(),
             "reward_estimator_state_dict": self.reward_estimator.state_dict(),
         }
@@ -2893,14 +2927,23 @@ class IPMD(PPO):
             and hasattr(self.env, "normalize_obs")
         ):
             data_to_save["vec_norm_msg"] = self.env.state_dict()
+        data_to_save.update(self._extra_checkpoint_state_dict())
 
         torch.save(data_to_save, target_path)
 
     def load_model(self, path: str) -> None:
         """Load PPO and reward-estimator state from a checkpoint."""
         data = torch.load(path, map_location=self.device)
-        if self.policy and "policy_state_dict" in data:
-            self.policy.load_state_dict(data["policy_state_dict"])  # type: ignore[arg-type]
+        self._load_checkpoint_policy_state_dict(data)
+        if not self._restore_training_state_from_checkpoint(data):
+            self._load_extra_checkpoint_state_dict(data)
+            if hasattr(self.env, "normalize_obs") and "vec_norm_msg" in data:
+                self.env.load_state_dict(data["vec_norm_msg"])  # type: ignore[arg-type]
+            self.log.info(
+                "Loaded student-primary IPMD-L2T policy for deployment; "
+                "skipped incompatible training state."
+            )
+            return
         if self.value_function and "value_state_dict" in data:
             self.value_function.load_state_dict(data["value_state_dict"])  # type: ignore[arg-type]
         if self.q_function and "q_state_dict" in data:
@@ -2940,6 +2983,7 @@ class IPMD(PPO):
             )
             if callable(load_checkpoint_state):
                 load_checkpoint_state(data["hl_skill_command_sampler_state_dict"])
+        self._load_extra_checkpoint_state_dict(data)
         if hasattr(self.env, "normalize_obs") and "vec_norm_msg" in data:
             self.env.load_state_dict(data["vec_norm_msg"])  # type: ignore[arg-type]
 
@@ -3323,7 +3367,9 @@ class IPMD(PPO):
                             )
                             if kl_approx is not None:
                                 loss.set("kl_approx", kl_approx.detach())
-                                self._maybe_adjust_lr(kl_approx, self.config.optim)
+                                self._record_kl_for_lr_adaptation(
+                                    kl_approx, self.config.optim
+                                )
 
                         losses[epoch_idx, batch_idx] = (
                             self._select_reported_loss_metrics(loss)
@@ -3331,6 +3377,10 @@ class IPMD(PPO):
 
                     if self.lr_scheduler and self.lr_scheduler_step == "epoch":
                         self.lr_scheduler.step()
+
+                # One adaptive-LR step per iteration under
+                # optim.kl_adapt_step="iteration"; a no-op otherwise.
+                self._flush_kl_lr_adaptation(self.config.optim)
 
         iteration.learn_time = time.perf_counter() - learn_start
         losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])

--- a/rlopt/agent/ipmd/ipmd.py
+++ b/rlopt/agent/ipmd/ipmd.py
@@ -2332,7 +2332,11 @@ class IPMD(PPO):
                 posterior_pg_renew_frac = renewal_mask.float().mean()
                 posterior_batch = batch[renewal_mask]
             latents = None
-            if posterior_batch.numel() > 0:
+            # TensorDict.numel() is lower-bounded to 1 by design (its own
+            # docstring: "a stack of two tensordict with empty shape will
+            # have two elements"), so it can never observe an empty-mask
+            # selection here -- check the mask directly instead.
+            if renewal_mask is None or bool(renewal_mask.any()):
                 latents = self._latent_learner.infer_batch_latents(
                     posterior_batch,
                     detach=False,

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -74,6 +74,13 @@ def _require_non_negative_int(name: str, value: int) -> int:
     return normalized
 
 
+def _env_offers_expert_batch(env: object) -> bool:
+    """Whether the environment exposes an expert-batch sampler."""
+    from rlopt.env_interface import resolve_imitation_interface, supports
+
+    return supports(resolve_imitation_interface(env), "sample_expert_batch")
+
+
 @dataclass
 class BilinearOfflinePretrainConfig:
     """Offline spectral-representation pretraining configuration."""
@@ -437,11 +444,12 @@ class IPMDBilinear(IPMD):
         if (
             offline_cfg.requires_offline_data()
             and not offline_dataset_enabled
-            and self._discover_env_method(env, "sample_expert_batch") is None
+            and not _env_offers_expert_batch(env)
         ):
             msg = (
-                "bilinear offline pretraining or policy BC requires "
-                "env.sample_expert_batch(...) or offline_dataset.enabled=True."
+                "bilinear offline pretraining or policy BC requires the "
+                "environment's sample_expert_batch capability or "
+                "offline_dataset.enabled=True."
             )
             raise ValueError(msg)
 

--- a/rlopt/agent/ipmd/ipmd_bilinear.py
+++ b/rlopt/agent/ipmd/ipmd_bilinear.py
@@ -1016,9 +1016,15 @@ class IPMDBilinear(IPMD):
         try:
             for iteration_idx in range(metadata.total_iterations):
                 iteration = self.collect(metadata, iteration_idx)
-                self.prepare(iteration, metadata)
-                self.iterate(iteration, metadata)
-                self.record(iteration, metadata)
+                with self._profile_iteration_phase(iteration.phase_times, "prepare"):
+                    self.prepare(iteration, metadata)
+                with self._profile_iteration_phase(iteration.phase_times, "learn"):
+                    self.iterate(iteration, metadata)
+                if "learn" in iteration.phase_times:
+                    iteration.learn_time = iteration.phase_times["learn"]
+                with self._profile_iteration_phase(iteration.phase_times, "record"):
+                    self.record(iteration, metadata)
+                self._finish_iteration_profile(metadata, iteration)
         finally:
             metadata.progress_bar.close()  # type: ignore[attr-defined]
             self.collector.shutdown()
@@ -1028,15 +1034,21 @@ class IPMDBilinear(IPMD):
         self, iteration: PPOIterationData, metadata: PPOTrainingMetadata
     ) -> None:
         super().prepare(iteration, metadata)
-        self._store_transitions(iteration.rollout)
+        with self._profile_iteration_phase(
+            iteration.phase_times, "prepare/history_buffer"
+        ):
+            self._store_transitions(iteration.rollout)
 
     def iterate(
         self, iteration: PPOIterationData, metadata: PPOTrainingMetadata
     ) -> None:
         super().iterate(iteration, metadata)
 
-        sr_metrics = self._train_sr_steps(self.config.bilinear.update_steps)
-        self.bilinear_rep.update_ema(self.config.bilinear.ema_tau)
+        with self._profile_iteration_phase(
+            iteration.phase_times, "learn/spectral_updates"
+        ):
+            sr_metrics = self._train_sr_steps(self.config.bilinear.update_steps)
+            self.bilinear_rep.update_ema(self.config.bilinear.ema_tau)
 
         for k, v in sr_metrics.items():
             self._pending_sr_metrics.setdefault(k, []).append(v)

--- a/rlopt/agent/ipmd/ipmd_l2t.py
+++ b/rlopt/agent/ipmd/ipmd_l2t.py
@@ -1,0 +1,404 @@
+"""IPMD with a privileged teacher and an online-distilled student actor."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torch import Tensor
+from torch.nn.utils import clip_grad_norm_
+from torchrl.data import ReplayBuffer
+from torchrl.record.loggers import Logger
+
+from rlopt.agent.ipmd.ipmd import IPMD, IPMDRLOptConfig
+from rlopt.config_base import NetworkConfig
+from rlopt.config_utils import ObsKey, normalize_batch_key
+from rlopt.type_aliases import OptimizerClass
+
+
+@dataclass
+class IPMDL2TConfig:
+    """Teacher-to-student distillation settings for :class:`IPMDL2T`."""
+
+    student_policy: NetworkConfig = field(default_factory=NetworkConfig)
+    """Deployable student actor layout and observation keys."""
+
+    imitation_coeff: float = 1.0
+    """Weight on executed-teacher-action mean-squared error."""
+
+    student_learning_rate: float | None = None
+    """Student LR; ``None`` reuses the configured teacher actor LR."""
+
+    student_max_grad_norm: float | None = None
+    """Student gradient clip; ``None`` reuses ``optim.max_grad_norm``."""
+
+    student_latent_key: ObsKey = ("policy", "latent_command")
+    """Deployable observation key receiving the mirrored teacher command."""
+
+    def validate(self) -> None:
+        """Validate the fixed v1 distillation contract."""
+        if float(self.imitation_coeff) <= 0.0:
+            msg = "ipmd_l2t.imitation_coeff must be positive."
+            raise ValueError(msg)
+        if (
+            self.student_learning_rate is not None
+            and float(self.student_learning_rate) <= 0.0
+        ):
+            msg = "ipmd_l2t.student_learning_rate must be positive."
+            raise ValueError(msg)
+        if (
+            self.student_max_grad_norm is not None
+            and float(self.student_max_grad_norm) <= 0.0
+        ):
+            msg = "ipmd_l2t.student_max_grad_norm must be positive."
+            raise ValueError(msg)
+        self.student_latent_key = normalize_batch_key(self.student_latent_key)
+
+
+@dataclass
+class IPMDL2TRLOptConfig(IPMDRLOptConfig):
+    """RLOpt configuration for privileged-teacher IPMD distillation."""
+
+    ipmd_l2t: IPMDL2TConfig = field(default_factory=IPMDL2TConfig)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.ipmd_l2t.validate()
+
+
+class IPMDL2T(IPMD):
+    """Train privileged IPMD and a deployable actor on the same rollouts.
+
+    ``config.policy`` is the privileged teacher. It must consume the exact
+    value-function observation keys. ``config.ipmd_l2t.student_policy`` is the
+    deployable student and is optimized only by behavior distillation from the
+    teacher action that actually controlled the environment.
+    """
+
+    config: IPMDL2TRLOptConfig
+    student_policy: TensorDictModule
+
+    def __init__(
+        self,
+        env,
+        config: IPMDL2TRLOptConfig,
+        policy_net: torch.nn.Module | None = None,
+        value_net: torch.nn.Module | None = None,
+        q_net: torch.nn.Module | None = None,
+        replay_buffer: type[ReplayBuffer] = ReplayBuffer,
+        logger: Logger | None = None,
+        feature_extractor_net: torch.nn.Module | None = None,
+        **kwargs,
+    ) -> None:
+        config.ipmd_l2t.validate()
+        if config.value_function is None:
+            msg = "IPMDL2T requires a value-function configuration."
+            raise ValueError(msg)
+
+        teacher_keys = [
+            normalize_batch_key(key) for key in config.policy.get_input_keys()
+        ]
+        critic_keys = [
+            normalize_batch_key(key) for key in config.value_function.get_input_keys()
+        ]
+        if teacher_keys != critic_keys:
+            msg = (
+                "IPMDL2T teacher policy inputs must exactly match value-function "
+                f"inputs, got teacher={teacher_keys!r}, critic={critic_keys!r}."
+            )
+            raise ValueError(msg)
+
+        architecture_fields = (
+            "num_cells",
+            "output_dim",
+            "activation_fn",
+            "normalize_input",
+            "normalization_epsilon",
+            "normalization_clip",
+        )
+        mismatched_architecture = [
+            field_name
+            for field_name in architecture_fields
+            if getattr(config.policy, field_name)
+            != getattr(config.ipmd_l2t.student_policy, field_name)
+        ]
+        if mismatched_architecture:
+            msg = "IPMDL2T student must match the teacher actor architecture; "
+            msg += f"mismatched fields: {mismatched_architecture!r}."
+            raise ValueError(msg)
+
+        self._student_obs_keys = [
+            normalize_batch_key(key)
+            for key in config.ipmd_l2t.student_policy.get_input_keys()
+        ]
+        self._student_latent_key = normalize_batch_key(
+            config.ipmd_l2t.student_latent_key
+        )
+        self._student_imitation_coeff = float(config.ipmd_l2t.imitation_coeff)
+        configured_student_clip = config.ipmd_l2t.student_max_grad_norm
+        configured_default_clip = getattr(config.optim, "max_grad_norm", None)
+        self._student_max_grad_norm = float(
+            configured_student_clip or configured_default_clip or 1.0e10
+        )
+
+        available_keys = set(env.observation_spec.keys(True))
+        missing_student_keys = [
+            key for key in self._student_obs_keys if key not in available_keys
+        ]
+        if missing_student_keys:
+            msg = (
+                "IPMDL2T student observation keys are missing from the environment: "
+                f"{missing_student_keys!r}."
+            )
+            raise ValueError(msg)
+        if config.ipmd.use_latent_command and (
+            self._student_latent_key not in self._student_obs_keys
+        ):
+            msg = (
+                "IPMDL2T latent mode requires student_policy.input_keys to contain "
+                f"{self._student_latent_key!r}."
+            )
+            raise ValueError(msg)
+
+        super().__init__(
+            env=env,
+            config=config,
+            policy_net=policy_net,
+            value_net=value_net,
+            q_net=q_net,
+            replay_buffer=replay_buffer,
+            logger=logger,
+            feature_extractor_net=feature_extractor_net,
+            **kwargs,
+        )
+
+    @property
+    def teacher_policy(self) -> TensorDictModule:
+        """Return the privileged policy used for rollout collection."""
+        assert self.policy is not None
+        return self.policy
+
+    @property
+    def deployment_policy(self):
+        """Return the deployable student, including latent-command injection."""
+        if not self._use_latent_command:
+            return self.student_policy
+        controller = self._require_latent_command_controller()
+        return controller.collector_policy(
+            inject_fn=self._inject_latent_command,
+            policy_module=self.student_policy,
+        )
+
+    def _set_optimizers(
+        self, optimizer_cls: OptimizerClass, optimizer_kwargs: dict[str, Any]
+    ) -> list[torch.optim.Optimizer]:
+        """Add an independent, non-KL-adaptive student optimizer."""
+        self.student_policy = self._construct_policy_from_config(
+            self.config.ipmd_l2t.student_policy
+        )
+        with torch.no_grad():
+            self.student_policy(self.env.fake_tensordict())
+
+        teacher_optimizers = super()._set_optimizers(optimizer_cls, optimizer_kwargs)
+        student_lr = self.config.ipmd_l2t.student_learning_rate
+        if student_lr is None:
+            student_lr = self.config.ipmd.actor_learning_rate
+        if student_lr is None:
+            student_lr = float(optimizer_kwargs["lr"])
+        student_params = {
+            "params": list(self.student_policy.parameters()),
+            "lr": float(student_lr),
+            "adaptive_lr": False,
+            "name": "student",
+        }
+        student_optimizer = optimizer_cls([student_params], **optimizer_kwargs)
+        return [*teacher_optimizers, student_optimizer]
+
+    def _refresh_grad_clip_params(self) -> None:
+        """Keep teacher and student gradient clipping fully independent."""
+        self._student_grad_clip_params = list(self.student_policy.parameters())
+        student_param_ids = {id(param) for param in self._student_grad_clip_params}
+        self._grad_clip_params = [
+            param
+            for group in self.optim.param_groups
+            for param in group["params"]
+            if id(param) not in student_param_ids
+        ]
+
+    def _refresh_parameter_monitor(self) -> None:
+        """Include the deployable actor in the normal finite-value checks."""
+        super()._refresh_parameter_monitor()
+        student_policy = getattr(self, "student_policy", None)
+        if student_policy is None:
+            return
+        seen = {id(param) for _, param in self._parameter_monitor}
+        for name, param in student_policy.named_parameters(recurse=True):
+            if id(param) in seen or not torch.is_floating_point(param):
+                continue
+            seen.add(id(param))
+            self._parameter_monitor.append((f"student_policy.{name}", param))
+
+    def _inject_latent_command(self, td: TensorDict) -> None:
+        """Generate one teacher command and mirror it exactly to the student."""
+        super()._inject_latent_command(td)
+        if not self._use_latent_command:
+            return
+        teacher_latent = td.get(self._latent_key)
+        if not isinstance(teacher_latent, Tensor):
+            msg = (
+                f"IPMDL2T expected a Tensor at teacher latent key {self._latent_key!r}."
+            )
+            raise RuntimeError(msg)
+        td.set(self._student_latent_key, teacher_latent)
+        student_latent = td.get(self._student_latent_key)
+        if not torch.equal(teacher_latent, student_latent):
+            msg = (
+                "IPMDL2T teacher and student latent commands must be tensor-identical."
+            )
+            raise RuntimeError(msg)
+
+    def _backward_student_imitation(self, batch: TensorDict) -> dict[str, Tensor]:
+        """Regress the student mean action to the detached executed action."""
+        teacher_action = batch.get("action")
+        if not isinstance(teacher_action, Tensor):
+            msg = "IPMDL2T rollout batch requires Tensor key 'action'."
+            raise RuntimeError(msg)
+        target = teacher_action.detach()
+        student_obs = batch.select(*self._student_obs_keys).detach()
+        student_dist = self.student_policy.get_dist(student_obs)  # type: ignore[attr-defined]
+        student_action = student_dist.deterministic_sample
+        error = student_action - target
+        imitation_mse = error.square().mean()
+        imitation_loss = imitation_mse * self._student_imitation_coeff
+        imitation_loss.backward()
+        return {
+            "loss_student_imitation": imitation_loss.detach(),
+            "student_action_mse": imitation_mse.detach(),
+            "student_action_mae": error.detach().abs().mean(),
+            "student_action_rmse": error.detach().square().mean().sqrt(),
+            "student_action_abs_mean": student_action.detach().abs().mean(),
+            "teacher_action_abs_mean": target.abs().mean(),
+        }
+
+    def update(  # ty: ignore[invalid-method-override]
+        self,
+        batch: TensorDict,
+        num_network_updates: int,
+        expert_batch: TensorDict,
+        has_expert: Tensor,
+    ) -> tuple[TensorDict, int]:
+        """Run unchanged IPMD teacher losses plus isolated student imitation."""
+        update_idx = (
+            int(num_network_updates.item())
+            if isinstance(num_network_updates, Tensor)
+            else int(num_network_updates)
+        )
+        self.optim.zero_grad(set_to_none=True)
+        bc_pretrain_active = update_idx < self._bc_pretrain_updates
+        output_loss = (
+            self._ppo_metrics_without_backward(batch)
+            if bc_pretrain_active
+            else self._backward_ppo_terms(batch)
+        )
+        bc_metrics = self._backward_bc_terms(expert_batch, has_expert)
+        rollout_bc_metrics = self._backward_rollout_bc_terms(batch)
+        student_metrics = self._backward_student_imitation(batch)
+
+        teacher_grad_norm = clip_grad_norm_(self._grad_clip_params, self._max_grad_norm)
+        student_grad_norm = clip_grad_norm_(
+            self._student_grad_clip_params, self._student_max_grad_norm
+        )
+
+        self.optim.step()
+        hl_skill_metrics = self._run_hl_skill_online_update(
+            batch,
+            update_idx=update_idx,
+        )
+
+        output_loss.set("alpha", torch.ones((), device=self.device))
+        for metrics in (bc_metrics, rollout_bc_metrics, student_metrics):
+            for key, value in metrics.items():
+                output_loss.set(key, value)
+        output_loss.set(
+            "bc_pretrain_active",
+            torch.tensor(
+                float(bc_pretrain_active),
+                device=self.device,
+                dtype=torch.float32,
+            ),
+        )
+        for key, value in hl_skill_metrics.items():
+            output_loss.set(key, value.detach())
+        output_loss.set("grad_norm", teacher_grad_norm.detach())
+        output_loss.set("student_grad_norm", student_grad_norm.detach())
+        return output_loss, num_network_updates + 1
+
+    @property
+    def _optional_loss_metrics(self) -> list[str]:
+        return [
+            *super()._optional_loss_metrics,
+            "loss_student_imitation",
+            "student_action_mse",
+            "student_action_mae",
+            "student_action_rmse",
+            "student_action_abs_mean",
+            "teacher_action_abs_mean",
+            "student_grad_norm",
+        ]
+
+    def _progress_summary_fields(self) -> tuple[tuple[str, str], ...]:
+        return (
+            *super()._progress_summary_fields(),
+            ("train/loss_student_imitation", "student_loss"),
+            ("train/student_action_rmse", "student_rmse"),
+        )
+
+    def _file_summary_fields(self) -> tuple[tuple[str, str], ...]:
+        return (
+            *super()._file_summary_fields(),
+            ("train/loss_student_imitation", "student_loss"),
+            ("train/student_action_rmse", "student_rmse"),
+            ("train/student_grad_norm", "student_grad"),
+        )
+
+    def _checkpoint_policy_state_dict(self) -> Mapping[str, Any]:
+        """Make the deployable student the checkpoint's primary policy."""
+        return self.student_policy.state_dict()
+
+    def _extra_checkpoint_state_dict(self) -> dict[str, Any]:
+        """Retain the privileged teacher for exact training resume."""
+        return {
+            "teacher_policy_state_dict": self.teacher_policy.state_dict(),
+            "checkpoint_metadata": {
+                "algorithm": "IPMD_L2T",
+                "primary_policy_role": "student",
+            },
+        }
+
+    def _restore_training_state_from_checkpoint(
+        self, checkpoint: Mapping[str, Any]
+    ) -> bool:
+        """Restore the full two-role training state for exact L2T resume."""
+        del checkpoint
+        return True
+
+    def _load_checkpoint_policy_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+        """Restore both roles and reject ambiguous ordinary-IPMD checkpoints."""
+        if "teacher_policy_state_dict" not in checkpoint:
+            msg = (
+                "IPMDL2T resume requires teacher_policy_state_dict; ordinary IPMD "
+                "checkpoints can only initialize a deployment IPMD agent."
+            )
+            raise ValueError(msg)
+        if "policy_state_dict" not in checkpoint:
+            msg = "IPMDL2T checkpoint is missing student policy_state_dict."
+            raise ValueError(msg)
+        self.student_policy.load_state_dict(checkpoint["policy_state_dict"])
+        self.teacher_policy.load_state_dict(checkpoint["teacher_policy_state_dict"])
+
+
+__all__ = ["IPMDL2T", "IPMDL2TConfig", "IPMDL2TRLOptConfig"]

--- a/rlopt/agent/ppo/ppo.py
+++ b/rlopt/agent/ppo/ppo.py
@@ -714,10 +714,16 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         self.actor_critic.eval()
         self.adv_module.eval()
 
+        phase_times: dict[str, float] = {}
         collect_start = time.perf_counter()
-        with timeit("collecting"):
+        with (
+            self._profile_iteration_phase(phase_times, "collect"),
+            timeit("collecting"),
+        ):
             rollout = next(run.collector_iter)
         collect_time = time.perf_counter() - collect_start
+        if "collect" in phase_times:
+            collect_time = phase_times["collect"]
 
         rollout_frames = rollout.numel()
         run.frames_processed += rollout_frames
@@ -728,6 +734,7 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
             rollout=rollout,
             frames=rollout_frames,
             collect_time=collect_time,
+            phase_times=phase_times,
         )
 
     def prepare(
@@ -818,39 +825,45 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
 
         with timeit("training"):
             # Pre-iteration compute GAE, once per rollout
-            iteration.rollout = self.pre_iteration_compute(iteration.rollout)
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/advantage_and_buffer"
+            ):
+                iteration.rollout = self.pre_iteration_compute(iteration.rollout)
 
             # Run PPO epochs over the rollout
-            for epoch_idx in range(metadata.epochs_per_rollout):
-                # Run PPO epochs over the rollout
-                for batch_idx, batch in enumerate(self.data_buffer):
-                    kl_context = None
-                    if (self.config.optim.scheduler or "").lower() == "adaptive":
-                        kl_context = self._prepare_kl_context(
-                            batch, metadata.policy_operator
+            with self._profile_iteration_phase(
+                iteration.phase_times, "learn/policy_updates"
+            ):
+                for epoch_idx in range(metadata.epochs_per_rollout):
+                    # Run PPO epochs over the rollout
+                    for batch_idx, batch in enumerate(self.data_buffer):
+                        kl_context = None
+                        if (self.config.optim.scheduler or "").lower() == "adaptive":
+                            kl_context = self._prepare_kl_context(
+                                batch, metadata.policy_operator
+                            )
+
+                        loss, metadata.updates_completed = self.update(
+                            batch, metadata.updates_completed
+                        )
+                        loss = loss.clone()
+
+                        if self.lr_scheduler and self.lr_scheduler_step == "update":
+                            self.lr_scheduler.step()
+                        if kl_context is not None:
+                            kl_approx = self._compute_kl_after_update(
+                                kl_context, metadata.policy_operator
+                            )
+                            if kl_approx is not None:
+                                loss.set("kl_approx", kl_approx.detach())
+                                self._maybe_adjust_lr(kl_approx, self.config.optim)
+
+                        losses[epoch_idx, batch_idx] = (
+                            self._select_reported_loss_metrics(loss)
                         )
 
-                    loss, metadata.updates_completed = self.update(
-                        batch, metadata.updates_completed
-                    )
-                    loss = loss.clone()
-
-                    if self.lr_scheduler and self.lr_scheduler_step == "update":
+                    if self.lr_scheduler and self.lr_scheduler_step == "epoch":
                         self.lr_scheduler.step()
-                    if kl_context is not None:
-                        kl_approx = self._compute_kl_after_update(
-                            kl_context, metadata.policy_operator
-                        )
-                        if kl_approx is not None:
-                            loss.set("kl_approx", kl_approx.detach())
-                            self._maybe_adjust_lr(kl_approx, self.config.optim)
-
-                    losses[epoch_idx, batch_idx] = self._select_reported_loss_metrics(
-                        loss
-                    )
-
-                if self.lr_scheduler and self.lr_scheduler_step == "epoch":
-                    self.lr_scheduler.step()
 
         iteration.learn_time = time.perf_counter() - learn_start
         losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])
@@ -980,13 +993,19 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
                 iteration = self.collect(metadata, iteration_idx)
 
                 # 2) Let the algorithm reshape rewards or attach extra data.
-                self.prepare(iteration, metadata)
+                with self._profile_iteration_phase(iteration.phase_times, "prepare"):
+                    self.prepare(iteration, metadata)
 
                 # 3) Run the shared learning phase over the prepared rollout.
-                self.iterate(iteration, metadata)
+                with self._profile_iteration_phase(iteration.phase_times, "learn"):
+                    self.iterate(iteration, metadata)
+                if "learn" in iteration.phase_times:
+                    iteration.learn_time = iteration.phase_times["learn"]
 
                 # 4) Log, refresh collector weights, and checkpoint if needed.
-                self.record(iteration, metadata)
+                with self._profile_iteration_phase(iteration.phase_times, "record"):
+                    self.record(iteration, metadata)
+                self._finish_iteration_profile(metadata, iteration)
         finally:
             metadata.progress_bar.close()  # type: ignore[attr-defined]
             self.collector.shutdown()

--- a/rlopt/agent/ppo/ppo.py
+++ b/rlopt/agent/ppo/ppo.py
@@ -323,9 +323,22 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
     def _construct_policy(
         self, policy_net: torch.nn.Module | None = None
     ) -> TensorDictModule:
-        """Construct policy"""
-        # for PPO, we use a probabilistic actor
+        """Construct the configured PPO policy."""
         assert isinstance(self.config, PPORLOptConfig)
+        return self._construct_policy_from_config(self.config.policy, policy_net)
+
+    def _construct_policy_from_config(
+        self,
+        policy_config: NetworkConfig,
+        policy_net: torch.nn.Module | None = None,
+    ) -> TensorDictModule:
+        """Construct one Gaussian actor from an explicit network config.
+
+        Keeping this builder independent of ``config.policy`` lets asymmetric
+        algorithms create deployable actors with different observation keys
+        while preserving PPO's distribution, normalization, and action-spec
+        behavior exactly.
+        """
 
         action_spec = self.env.action_spec_unbatched  # type: ignore
         action_dim = int(action_spec.shape[-1])  # type: ignore[attr-defined]
@@ -343,29 +356,29 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         # Build policy network
         if policy_net is None:
             policy_mlp = MLP(
-                in_features=self.config.policy.input_dim,
-                activation_class=get_activation_class(self.config.policy.activation_fn),
+                in_features=policy_config.input_dim,
+                activation_class=get_activation_class(policy_config.activation_fn),
                 out_features=action_dim,
-                num_cells=list(self.config.policy.num_cells),
+                num_cells=list(policy_config.num_cells),
                 device=self.device,
             )
         else:
             policy_mlp = policy_net
 
-        if getattr(self.config.policy, "normalize_input", False):
+        if getattr(policy_config, "normalize_input", False):
             # SONIC-style running observation normalization for the actor.
             # GaussianPolicyHead concatenates multi-key inputs before calling
             # the base module, so the normalizer always receives one tensor.
-            policy_in_keys = self.config.policy.get_input_keys()
+            policy_in_keys = policy_config.get_input_keys()
             feature_dim = sum(
                 self.observation_feature_size(key) for key in policy_in_keys
             )
             policy_mlp = RunningMeanStdCatInputs(
                 policy_mlp,
                 feature_dim,
-                epsilon=self.config.policy.normalization_epsilon,
-                clip=self.config.policy.normalization_clip,
-                normalize_mask=self._input_normalize_mask(self.config.policy),
+                epsilon=policy_config.normalization_epsilon,
+                clip=policy_config.normalization_clip,
+                normalize_mask=self._input_normalize_mask(policy_config),
             )
 
         net = GaussianPolicyHead(
@@ -381,7 +394,7 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
         # Wrap in TensorDictModule
         policy_td = TensorDictModule(
             module=net,
-            in_keys=self.config.policy.get_input_keys(),
+            in_keys=policy_config.get_input_keys(),
             out_keys=["loc", "scale"],
         )
 
@@ -856,7 +869,9 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
                             )
                             if kl_approx is not None:
                                 loss.set("kl_approx", kl_approx.detach())
-                                self._maybe_adjust_lr(kl_approx, self.config.optim)
+                                self._record_kl_for_lr_adaptation(
+                                    kl_approx, self.config.optim
+                                )
 
                         losses[epoch_idx, batch_idx] = (
                             self._select_reported_loss_metrics(loss)
@@ -864,6 +879,10 @@ class PPO(BaseAlgorithm[PpoCfgT], Generic[PpoCfgT]):
 
                     if self.lr_scheduler and self.lr_scheduler_step == "epoch":
                         self.lr_scheduler.step()
+
+                # One adaptive-LR step per iteration under
+                # optim.kl_adapt_step="iteration"; a no-op otherwise.
+                self._flush_kl_lr_adaptation(self.config.optim)
 
         iteration.learn_time = time.perf_counter() - learn_start
         losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])

--- a/rlopt/agent/skill_commander.py
+++ b/rlopt/agent/skill_commander.py
@@ -2185,15 +2185,13 @@ class FrozenSkillCommanderSampler(FrozenHighLevelSkillCommandSampler):
         )
         self.device = _resolve_device(device, env)
 
-        self._current_macro_sampler = discover_env_method(
-            env, "current_expert_macro_transition_batch"
+        from rlopt.env_interface import require_imitation_interface
+
+        self._current_macro_sampler = require_imitation_interface(
+            env,
+            "current_expert_macro_transition_batch",
+            purpose="command_source='skill_commander' requires it but",
         )
-        if self._current_macro_sampler is None:
-            msg = (
-                "command_source='skill_commander' requires the environment to "
-                "expose current_expert_macro_transition_batch(...)."
-            )
-            raise ValueError(msg)
         # Closed-loop mode: condition the commander on robot-only causal history.
         self.use_achieved_state = bool(use_achieved_state)
         self._achieved_macro_sampler = discover_env_method(
@@ -2447,7 +2445,14 @@ class FrozenSkillCommanderSampler(FrozenHighLevelSkillCommandSampler):
             self.diffsr.requires_grad_(False)
 
         if self.condition_on_language:
-            names_provider = discover_env_method(env, "expert_trajectory_motion_names")
+            from rlopt.env_interface import resolve_imitation_interface, supports
+
+            _interface = resolve_imitation_interface(env)
+            names_provider = (
+                _interface.expert_trajectory_motion_names
+                if supports(_interface, "expert_trajectory_motion_names")
+                else None
+            )
             if names_provider is None:
                 msg = (
                     "command_source='skill_commander' requires the environment to "

--- a/rlopt/base_class.py
+++ b/rlopt/base_class.py
@@ -391,10 +391,13 @@ class BaseAlgorithm(Generic[CfgT], ABC):
         return None
 
     def _auto_attach_env_expert_sampler(self) -> None:
-        """Attach ``sample_expert_batch`` from env wrappers when available."""
-        sampler = self._discover_env_method(self.env, "sample_expert_batch")
-        if sampler is None:
+        """Attach the environment's expert sampler when it offers one."""
+        from rlopt.env_interface import resolve_imitation_interface, supports
+
+        interface = resolve_imitation_interface(self.env)
+        if not supports(interface, "sample_expert_batch"):
             return
+        sampler = interface.sample_expert_batch
 
         def _wrapped_sampler(
             batch_size: int, required_keys: list[str | tuple[str, ...]]

--- a/rlopt/base_class.py
+++ b/rlopt/base_class.py
@@ -1372,6 +1372,46 @@ class BaseAlgorithm(Generic[CfgT], ABC):
             return None
         return kl_approx
 
+    def _record_kl_for_lr_adaptation(
+        self, kl_approx: Tensor, schedule_cfg: Any
+    ) -> None:
+        """Route one minibatch's KL sample to the adaptive-LR rule.
+
+        Under ``optim.kl_adapt_step="update"`` this is a direct call and the
+        behaviour is exactly as before. Under ``"iteration"`` the sample is
+        buffered instead, and :meth:`_flush_kl_lr_adaptation` applies a single
+        bang-bang step per iteration on the mean.
+        """
+        mode = str(getattr(schedule_cfg, "kl_adapt_step", "update") or "update").lower()
+        if mode != "iteration":
+            self._maybe_adjust_lr(kl_approx, schedule_cfg)
+            return
+        kl_value = float(kl_approx.detach().mean().cpu().item())
+        if not np.isfinite(kl_value):
+            return
+        # Lazily created: concrete agents build a lot of state in __init__, and
+        # this only has to exist by the first update.
+        samples = getattr(self, "_kl_adapt_samples", None)
+        if samples is None:
+            samples = []
+            self._kl_adapt_samples = samples
+        samples.append(kl_value)
+
+    def _flush_kl_lr_adaptation(self, schedule_cfg: Any) -> None:
+        """Apply the buffered per-iteration adaptive-LR step, if any.
+
+        A no-op under ``kl_adapt_step="update"``, where the buffer never fills,
+        so it is safe to call unconditionally at the end of an update loop.
+        """
+        samples = getattr(self, "_kl_adapt_samples", None)
+        if not samples:
+            return
+        mean_kl = float(np.mean(samples))
+        samples.clear()
+        self._maybe_adjust_lr(
+            torch.as_tensor(mean_kl, dtype=torch.float32), schedule_cfg
+        )
+
     def _maybe_adjust_lr(self, kl_approx: Tensor, schedule_cfg: Any) -> None:
         schedule = (getattr(schedule_cfg, "scheduler", "") or "").lower()
         if schedule != "adaptive":

--- a/rlopt/base_class.py
+++ b/rlopt/base_class.py
@@ -6,7 +6,8 @@ import math
 import time
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, TypeVar, cast
@@ -84,6 +85,8 @@ class IterationData:
     collect_time: float = 0.0
     # Time spent learning/logging after collection for this iteration.
     learn_time: float = 0.0
+    # Opt-in synchronized wall times for the named phases in this iteration.
+    phase_times: dict[str, float] = field(default_factory=dict)
     # Scalar metrics accumulated while handling this iteration.
     metrics: dict[str, Any] = field(default_factory=dict)
 
@@ -147,6 +150,82 @@ class BaseAlgorithm(Generic[CfgT], ABC):
     """
 
     _FILE_SUMMARY_HEADER_INTERVAL = 20
+
+    def _iteration_profiling_enabled(self) -> bool:
+        """Whether synchronized per-iteration phase profiling is enabled."""
+        trainer = getattr(self.config, "trainer", None)
+        return bool(trainer and getattr(trainer, "profile_iterations", False))
+
+    def _synchronize_profile_device(self) -> None:
+        """Drain queued accelerator work at an opt-in profiling boundary."""
+        if not self._iteration_profiling_enabled() or not torch.cuda.is_available():
+            return
+        device = torch.device(self.device)
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+    @contextmanager
+    def _profile_iteration_phase(
+        self,
+        phase_times: MutableMapping[str, float],
+        name: str,
+    ) -> Iterator[None]:
+        """Accumulate synchronized wall time for one named iteration phase."""
+        if not self._iteration_profiling_enabled():
+            yield
+            return
+
+        self._synchronize_profile_device()
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._synchronize_profile_device()
+            elapsed = time.perf_counter() - start
+            phase_times[name] = phase_times.get(name, 0.0) + elapsed
+
+    def _finish_iteration_profile(
+        self,
+        metadata: TrainingMetadata,
+        iteration: IterationData,
+    ) -> None:
+        """Emit scalar and text summaries after all iteration phases complete."""
+        if not self._iteration_profiling_enabled():
+            return
+
+        top_level_names = ("collect", "prepare", "learn", "record")
+        total = sum(iteration.phase_times.get(name, 0.0) for name in top_level_names)
+        metrics = {
+            f"profile/{name}_s": value for name, value in iteration.phase_times.items()
+        }
+        metrics["profile/total_s"] = total
+        metrics["profile/frames_per_second"] = (
+            float(iteration.frames) / total if total > 0.0 else 0.0
+        )
+        self.log_metrics(
+            metrics,
+            step=metadata.frames_processed,
+            log_python=False,
+        )
+
+        top_level = " ".join(
+            f"{name}={iteration.phase_times.get(name, 0.0) * 1_000.0:.2f}ms"
+            for name in top_level_names
+        )
+        details = " ".join(
+            f"{name.split('/', maxsplit=1)[-1]}={elapsed * 1_000.0:.2f}ms"
+            for name, elapsed in iteration.phase_times.items()
+            if "/" in name
+        )
+        message = (
+            "iteration_profile | "
+            f"iter={iteration.iteration_idx + 1}/{metadata.total_iterations} | "
+            f"{top_level} total={total * 1_000.0:.2f}ms | "
+            f"fps={metrics['profile/frames_per_second']:.1f}"
+        )
+        if details:
+            message = f"{message} | detail: {details}"
+        self.log.info(message)
 
     def __init__(
         self,

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -453,6 +453,9 @@ class TrainerConfig:
     log_interval: int = 10_000_000
     """Interval for logging."""
 
+    profile_iterations: bool = False
+    """Synchronize accelerators and report phase timings for every iteration."""
+
 
 @dataclass
 class RLOptConfig:

--- a/rlopt/config_base.py
+++ b/rlopt/config_base.py
@@ -274,6 +274,22 @@ class OptimizerConfig:
     lr_adaptation_factor: float = 1.5
     """Factor to scale LR up/down for adaptive schedule."""
 
+    kl_adapt_step: Literal["update", "iteration"] = "update"
+    """How often the adaptive-KL rule may change the learning rate.
+
+    ``"update"`` is the historical behaviour: the bang-bang rule fires after
+    every minibatch, so a rollout split into ``m`` minibatches over ``e`` epochs
+    moves the LR up to ``m * e`` times per iteration. At the geometries used for
+    G1 imitation that is 40-80 multiplicative steps per iteration, and the
+    measured log-LR ends up serially uncorrelated (lag-1 autocorrelation ~0 over
+    a 3.5B-frame run) -- a random walk inside the clamp band rather than a
+    controller with a fixed point.
+
+    ``"iteration"`` buffers the per-minibatch KL samples and applies exactly one
+    step per iteration on their mean, which is the regime the dead-band rule
+    actually assumes. Left at ``"update"`` so existing runs are unchanged.
+    """
+
     min_lr: float | None = 1e-6
     """Lower bound for adaptive learning rate. None disables clamping."""
 

--- a/rlopt/env_interface.py
+++ b/rlopt/env_interface.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2022-2026, The RLOpt developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""The one imitation-environment surface RLOpt knows about.
+
+Agents used to duck-type the environment in a dozen places, each walking the
+wrapper stack for a differently-named method (``sample_expert_batch``,
+``current_expert_macro_transition_batch``, ``set_agent_latent_command``, ...).
+That spread the environment's API across the whole package and made every
+environment-side rename an RLOpt change.
+
+Instead there is ONE capability object. An imitation environment exposes it as
+``env.imitation_interface``; RLOpt resolves it once
+(:func:`resolve_imitation_interface`) and everything else is typed attribute
+access on :class:`ImitationEnvInterface`. Environments that predate the
+attribute are still supported: :class:`LegacyMethodInterface` adapts the
+historical method names, so this module is the only place in RLOpt that knows
+them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from torch import Tensor
+from tensordict import TensorDict
+
+__all__ = [
+    "ImitationEnvInterface",
+    "LegacyMethodInterface",
+    "require_imitation_interface",
+    "resolve_imitation_interface",
+    "supports",
+]
+
+# The wrapper attributes an environment stack is threaded through.
+_WRAPPER_ATTRS = ("base_env", "env", "_env", "unwrapped")
+
+# Capability name -> the historical environment method it was called by.
+_LEGACY_METHOD_NAMES: dict[str, str] = {
+    "sample_expert_batch": "sample_expert_batch",
+    "sample_expert_macro_transition_batch": "sample_expert_macro_transition_batch",
+    "current_expert_macro_transition_batch": "current_expert_macro_transition_batch",
+    "current_achieved_macro_transition_batch": "current_achieved_macro_transition_batch",
+    "expert_macro_feature_slices": "expert_macro_feature_slices",
+    "expert_trajectory_motion_names": "expert_trajectory_motion_names",
+    "offline_dataset_mapper_params": "get_offline_dataset_mapper_params",
+    "publish_actor_command": "set_agent_latent_command",
+}
+
+
+@runtime_checkable
+class ImitationEnvInterface(Protocol):
+    """What an imitation environment offers an RLOpt agent.
+
+    Every member is optional in the sense that a given environment may not
+    implement it (a vanilla tracking task has no skill encoder to feed); use
+    :func:`supports` to probe, and fail loudly naming the capability when the
+    configured algorithm requires one that is absent.
+    """
+
+    def sample_expert_batch(
+        self, batch_size: int, required_keys: Sequence[Any]
+    ) -> TensorDict | None:
+        """Expert transitions for the imitation/IRL losses."""
+        ...
+
+    def sample_expert_macro_transition_batch(
+        self,
+        batch_size: int,
+        horizon_steps: int,
+        split: str | None = None,
+        eval_fraction: float = 0.1,
+        split_seed: int = 0,
+        trajectory_ranks: Sequence[int] | Tensor | None = None,
+        state_history_steps: int = 0,
+    ) -> TensorDict:
+        """Offline expert macro-transitions for skill-encoder training."""
+        ...
+
+    def current_expert_macro_transition_batch(
+        self,
+        horizon_steps: int,
+        env_ids: Tensor | Sequence[int] | None = None,
+        state_history_steps: int = 0,
+    ) -> TensorDict:
+        """The live expert macro-transition at each environment's cursor."""
+        ...
+
+    def expert_macro_feature_slices(self, horizon_steps: int) -> dict[str, Any]:
+        """Feature-name to slice map of one macro-state frame."""
+        ...
+
+    def expert_trajectory_motion_names(self) -> list[str]:
+        """Motion name per trajectory rank."""
+        ...
+
+    def offline_dataset_mapper_params(self) -> dict[str, Any]:
+        """Parameters mapping an offline dataset onto this environment's keys."""
+        ...
+
+    def publish_actor_command(
+        self, command: Tensor, env_ids: Tensor | None = None
+    ) -> None:
+        """Publish the agent-produced actor command (e.g. a skill latent)."""
+        ...
+
+
+class LegacyMethodInterface:
+    """Adapter over an environment that predates ``imitation_interface``.
+
+    Resolves each capability lazily by walking the wrapper stack for its
+    historical method name, so an environment only pays for what an agent
+    actually asks for and a missing capability is reported by name.
+    """
+
+    def __init__(self, env: object) -> None:
+        self._env = env
+        self._cache: dict[str, Callable | None] = {}
+
+    def __repr__(self) -> str:
+        return f"LegacyMethodInterface({type(self._env).__name__})"
+
+    def _method(self, capability: str) -> Callable | None:
+        if capability in self._cache:
+            return self._cache[capability]
+        method_name = _LEGACY_METHOD_NAMES.get(capability)
+        method = (
+            None if method_name is None else _walk_for_callable(self._env, method_name)
+        )
+        self._cache[capability] = method
+        return method
+
+    def __getattr__(self, name: str) -> Callable:
+        method = self._method(name)
+        if method is None:
+            raise AttributeError(
+                f"The environment does not expose the {name!r} capability."
+            )
+        return method
+
+
+def _walk_for_callable(env: object, method_name: str) -> Callable | None:
+    """Find a callable attribute anywhere in the wrapper stack."""
+    stack: list[object] = [env]
+    visited: set[int] = set()
+    while stack:
+        current = stack.pop()
+        obj_id = id(current)
+        if obj_id in visited:
+            continue
+        visited.add(obj_id)
+        method = getattr(current, method_name, None)
+        if callable(method):
+            return method
+        for attr_name in _WRAPPER_ATTRS:
+            try:
+                next_obj = getattr(current, attr_name, None)
+            except Exception:
+                continue
+            if next_obj is None:
+                continue
+            if isinstance(next_obj, list | tuple):
+                stack.extend(next_obj)
+            else:
+                stack.append(next_obj)
+    return None
+
+
+def resolve_imitation_interface(env: object) -> ImitationEnvInterface:
+    """The environment's imitation interface -- the single resolution point.
+
+    Walks the wrapper stack once for an ``imitation_interface`` attribute and
+    falls back to :class:`LegacyMethodInterface` for environments that expose
+    the historical method names instead. Always returns an object; probe it
+    with :func:`supports` and fail loudly where a capability is required.
+    """
+    stack: list[object] = [env]
+    visited: set[int] = set()
+    while stack:
+        current = stack.pop()
+        obj_id = id(current)
+        if obj_id in visited:
+            continue
+        visited.add(obj_id)
+        interface = getattr(current, "imitation_interface", None)
+        if interface is not None:
+            return interface
+        for attr_name in _WRAPPER_ATTRS:
+            try:
+                next_obj = getattr(current, attr_name, None)
+            except Exception:
+                continue
+            if next_obj is None:
+                continue
+            if isinstance(next_obj, list | tuple):
+                stack.extend(next_obj)
+            else:
+                stack.append(next_obj)
+    return LegacyMethodInterface(env)
+
+
+def supports(interface: object, capability: str) -> bool:
+    """Whether an interface actually provides a capability."""
+    try:
+        return callable(getattr(interface, capability, None))
+    except AttributeError:
+        return False
+
+
+def require_imitation_interface(
+    env: object, capability: str, *, purpose: str
+) -> Callable:
+    """Resolve one required capability, failing loudly when it is absent."""
+    interface = resolve_imitation_interface(env)
+    if not supports(interface, capability):
+        raise ValueError(
+            f"{purpose} the environment does not expose the {capability!r} "
+            "capability of its imitation interface."
+        )
+    return getattr(interface, capability)

--- a/rlopt/expert/stream.py
+++ b/rlopt/expert/stream.py
@@ -203,26 +203,13 @@ class StreamingOfflineExpertSampler:
 
 
 def _discover_offline_mapper_params(env: object) -> dict[str, Any]:
-    stack: list[object] = [env]
-    visited: set[int] = set()
-    while stack:
-        current = stack.pop()
-        obj_id = id(current)
-        if obj_id in visited:
-            continue
-        visited.add(obj_id)
-        method = getattr(current, "get_offline_dataset_mapper_params", None)
-        if callable(method):
-            return dict(method())
-        for attr_name in ("base_env", "env", "_env", "unwrapped"):
-            next_obj = getattr(current, attr_name, None)
-            if next_obj is None:
-                continue
-            if isinstance(next_obj, list | tuple):
-                stack.extend(next_obj)
-            else:
-                stack.append(next_obj)
-    return {}
+    """Offline-dataset mapper parameters from the environment's interface."""
+    from rlopt.env_interface import resolve_imitation_interface, supports
+
+    interface = resolve_imitation_interface(env)
+    if not supports(interface, "offline_dataset_mapper_params"):
+        return {}
+    return dict(interface.offline_dataset_mapper_params())
 
 
 def build_offline_expert_sampler(

--- a/rlopt/logging_utils.py
+++ b/rlopt/logging_utils.py
@@ -464,9 +464,15 @@ class LoggingManager:
         except Exception:  # pragma: no cover - defensive
             pass
 
+        # TorchRL's get_logger routes the file-backed loggers to ``logger_name``
+        # and ignores the ``log_dir`` kwarg entirely, so passing the component
+        # name there scattered scalars into a ``./csv``-style directory beside
+        # the process CWD instead of the configured run directory. Only wandb
+        # reads log_dir/wandb_kwargs, so leave its argument alone.
+        file_backed = backend in ("csv", "tensorboard")
         return get_logger(
             backend,
-            logger_name=self.component.lower(),
+            logger_name=str(self.run_dir) if file_backed else self.component.lower(),
             experiment_name=exp_name,
             log_dir=str(self.run_dir),
             wandb_kwargs=wandb_kwargs,

--- a/rlopt/utils.py
+++ b/rlopt/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any
+from typing import Any, Protocol
 
 import gymnasium as gym
 import numpy as np
@@ -634,6 +634,64 @@ def discover_env_method(env: object, method_name: str) -> Callable | None:
             else:
                 stack.append(next_obj)
     return None
+
+
+def require_env_method(env: object, method_name: str, *, purpose: str) -> Callable:
+    """Discover an env method, failing loudly when it is absent.
+
+    Same wrapper walk as :func:`discover_env_method`, but raises a
+    ``ValueError`` naming the missing capability and its purpose instead of
+    returning ``None`` -- use it where a method is a hard requirement of the
+    configured algorithm (e.g. ``command_source='hl_skill'`` needs
+    ``current_expert_macro_transition_batch``). Same exception contract as
+    the manual discovery + ``ValueError`` checks it replaces.
+    """
+    method = discover_env_method(env, method_name)
+    if method is None:
+        raise ValueError(
+            f"{purpose} {method_name}(...) is not exposed by the environment."
+        )
+    return method
+
+
+class ExpertProvider(Protocol):
+    """The expert-data surface RLOpt agents discover on imitation envs.
+
+    Typed discovery contract for the env methods used by the expert
+    samplers / latent-command pipelines. Implemented by the Isaac Lab
+    imitation envs (v2 and the frozen legacy env) and by any equivalent
+    environment; agents should resolve them with
+    :func:`discover_env_method` (optional) or :func:`require_env_method`
+    (mandatory) rather than importing the env class.
+    """
+
+    def sample_expert_batch(
+        self, batch_size: int, required_keys: Sequence[Any]
+    ) -> TensorDict | None: ...
+
+    def sample_expert_macro_transition_batch(
+        self,
+        batch_size: int,
+        horizon_steps: int,
+        split: str | None = None,
+        eval_fraction: float = 0.1,
+        split_seed: int = 0,
+        trajectory_ranks: Sequence[int] | Tensor | None = None,
+        state_history_steps: int = 0,
+    ) -> TensorDict: ...
+
+    def current_expert_macro_transition_batch(
+        self,
+        horizon_steps: int,
+        env_ids: Tensor | Sequence[int] | None = None,
+        state_history_steps: int = 0,
+    ) -> TensorDict: ...
+
+    def set_agent_latent_command(
+        self, latent_command: Tensor, env_ids: Tensor | None = None
+    ) -> None: ...
+
+    def expert_trajectory_motion_names(self) -> list[str]: ...
 
 
 def grad_penalty(

--- a/tests/test_hl_skill_encoder.py
+++ b/tests/test_hl_skill_encoder.py
@@ -1,0 +1,182 @@
+"""Tests for the high-level skill encoders, focused on the SONIC-motivated FSQ mode.
+
+``SONICFSQSkillEncoder`` exists so the planner -> tracker command boundary sits at
+the quantizer output, which is what makes the interface genuinely quantized rather
+than merely trained through a quantizer. These tests pin that contract and guard
+the pre-existing ``fsq``/``FSQQuantizer`` paths against regression, because the
+qualified ``latent_skill`` oracle checkpoint depends on them.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rlopt.agent.hl_skill_diffsr import HighLevelSkillDiffSRConfig
+from rlopt.agent.hl_skill_encoder import (
+    FSQQuantizer,
+    FSQSkillEncoder,
+    SkillLatentSpec,
+    SONICFSQSkillEncoder,
+    build_skill_encoder,
+)
+
+# gear_sonic all_mlp_v1.yaml: num_fsq_levels=32, max_num_tokens=2 -> 64 values.
+SONIC_LEVELS: tuple[int, ...] = (32,) * 64
+STATE_DIM = 93
+WINDOW_STEPS = 10
+
+
+def _build(levels: tuple[int, ...], z_dim: int | None = None):
+    return build_skill_encoder(
+        state_dim=STATE_DIM,
+        window_steps=WINDOW_STEPS,
+        z_dim=len(levels) if z_dim is None else z_dim,
+        hidden_dims=(256, 128),
+        spec=SkillLatentSpec(latent_mode="sonic_fsq", sonic_fsq_levels=levels),
+    )
+
+
+def _batch(batch_size: int = 8):
+    torch.manual_seed(0)
+    return (
+        torch.randn(batch_size, STATE_DIM),
+        torch.randn(batch_size, WINDOW_STEPS, STATE_DIM),
+    )
+
+
+def test_factory_builds_sonic_fsq_encoder():
+    assert isinstance(_build(SONIC_LEVELS), SONICFSQSkillEncoder)
+
+
+def test_command_width_equals_token_width():
+    """The published command is the token itself, not a projection of it."""
+    encoder = _build(SONIC_LEVELS)
+    z, _, _ = encoder.encode(*_batch(), deterministic=True)
+    assert z.shape == (8, len(SONIC_LEVELS))
+
+
+def test_command_lies_on_normalized_lattice():
+    """Matches gear_sonic's LATENT_INITIAL_MOTION_TOKEN: exact multiples of 1/16."""
+    encoder = _build(SONIC_LEVELS)
+    z, _, _ = encoder.encode(*_batch(), deterministic=True)
+    half = SONIC_LEVELS[0] // 2
+    scaled = z * half
+    assert torch.allclose(scaled, scaled.round(), atol=1e-5)
+    assert bool((z.abs() <= 1.0 + 1e-6).all())
+
+
+def test_lattice_holds_for_odd_and_mixed_levels():
+    for levels in [(5,) * 8, (8, 8, 8, 5, 5)]:
+        encoder = _build(levels)
+        z, _, _ = encoder.encode(*_batch(), deterministic=True)
+        half = torch.tensor([max(level // 2, 1) for level in levels], dtype=z.dtype)
+        scaled = z * half
+        assert torch.allclose(scaled, scaled.round(), atol=1e-5), levels
+        assert bool((z.abs() <= 1.0 + 1e-6).all()), levels
+
+
+def test_no_learned_projection_at_the_command_boundary():
+    encoder = _build(SONIC_LEVELS)
+    assert isinstance(encoder.code_to_latent, torch.nn.Identity)
+
+
+def test_straight_through_gradient_reaches_the_trunk():
+    """Rounding must not block gradient: this is what co-training depends on."""
+    encoder = _build(SONIC_LEVELS)
+    z, _, _ = encoder.encode(*_batch(), deterministic=True)
+    z.pow(2).mean().backward()
+    grads = [
+        param.grad
+        for param in encoder.net.parameters()
+        if param.grad is not None and bool(param.grad.abs().sum() > 0)
+    ]
+    assert grads, "no gradient reached the encoder trunk through the quantizer"
+
+
+def test_regularizer_is_zero():
+    """FSQ needs no commitment/KL term; reg_coeff must have nothing to scale."""
+    _, reg, _ = _build(SONIC_LEVELS).encode(*_batch(), deterministic=True)
+    assert float(reg.detach()) == 0.0
+
+
+def test_z_dim_must_equal_token_width():
+    with pytest.raises(ValueError, match="z_dim must equal"):
+        _build(SONIC_LEVELS, z_dim=256)
+
+
+def test_sonic_token_space_capacity():
+    """64 dims x 32 levels = 2**320; a flat int64 code index cannot exist."""
+    encoder = _build(SONIC_LEVELS)
+    assert encoder.fsq.codebook_size == 32**64
+    assert not encoder.fsq.flat_code_supported
+    # Falls back to per-dim level indices, pooled by the usage metrics.
+    assert encoder.num_codes == 32
+
+
+# --------------------------------------------------------------------------- #
+# Regression guards: the pre-existing paths must be untouched.
+# --------------------------------------------------------------------------- #
+def test_fsq_quantizer_still_returns_the_unnormalized_integer_grid():
+    quantizer = FSQQuantizer((32,) * 4)
+    torch.manual_seed(0)
+    z_q, _ = quantizer(torch.randn(16, 4) * 5.0)
+    assert torch.allclose(z_q, z_q.round(), atol=1e-5)
+    assert float(z_q.abs().max()) > 1.0
+
+
+def test_fsq_encoder_still_projects_to_z_dim():
+    encoder = build_skill_encoder(
+        state_dim=STATE_DIM,
+        window_steps=WINDOW_STEPS,
+        z_dim=256,
+        hidden_dims=(256, 128),
+        spec=SkillLatentSpec(latent_mode="fsq", fsq_levels=(8, 8, 8, 5, 5)),
+    )
+    assert isinstance(encoder, FSQSkillEncoder)
+    assert isinstance(encoder.code_to_latent, torch.nn.Linear)
+    z, _, _ = encoder.encode(*_batch(), deterministic=True)
+    assert z.shape == (8, 256)
+
+
+# --------------------------------------------------------------------------- #
+# Config plumbing.
+# --------------------------------------------------------------------------- #
+def _config(**overrides) -> HighLevelSkillDiffSRConfig:
+    """Validation lives in an explicit ``validate()``, so call it here."""
+    base = {
+        "horizon_steps": WINDOW_STEPS,
+        "latent_mode": "sonic_fsq",
+        "z_dim": len(SONIC_LEVELS),
+        "sonic_fsq_levels": SONIC_LEVELS,
+    }
+    base.update(overrides)
+    config = HighLevelSkillDiffSRConfig(**base)
+    config.validate()
+    return config
+
+
+def test_config_rejects_z_dim_mismatch():
+    with pytest.raises(ValueError, match="z_dim must equal len"):
+        _config(z_dim=256)
+
+
+def test_config_projects_levels_into_the_encoder_spec():
+    spec = _config().latent_spec()
+    assert spec.latent_mode == "sonic_fsq"
+    assert spec.sonic_fsq_levels == SONIC_LEVELS
+
+
+def test_config_round_trips_through_dict():
+    restored = HighLevelSkillDiffSRConfig.from_dict(_config().to_dict())
+    assert restored.sonic_fsq_levels == SONIC_LEVELS
+    assert restored.latent_mode == "sonic_fsq"
+
+
+def test_config_leaves_other_latent_modes_alone():
+    """sonic_fsq_levels must not constrain z_dim for the pre-existing modes."""
+    config = HighLevelSkillDiffSRConfig(
+        horizon_steps=WINDOW_STEPS, latent_mode="fsq", z_dim=256
+    )
+    config.validate()
+    assert config.latent_spec().latent_mode == "fsq"

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -1300,6 +1300,64 @@ def test_ipmd_iterate_updates_reward_before_reward_recompute_and_advantage() -> 
     assert order == ["reward_update", "reward_recompute", "advantage"]
 
 
+def test_iteration_profiler_accumulates_and_reports(monkeypatch) -> None:
+    """Opt-in iteration profiling should synchronize boundaries and emit metrics."""
+    _rlopt()
+    from rlopt.base_class import IterationData, TrainingMetadata
+
+    agent, _env = _make_env_reward_only_ipmd_agent()
+    assert agent.config.trainer is not None
+    agent.config.trainer.profile_iterations = True
+    sync_calls: list[None] = []
+    logged_metrics: dict[str, float] = {}
+    messages: list[str] = []
+
+    monkeypatch.setattr(
+        agent,
+        "_synchronize_profile_device",
+        lambda: sync_calls.append(None),
+    )
+    monkeypatch.setattr(
+        agent,
+        "log_metrics",
+        lambda metrics, **_kwargs: logged_metrics.update(metrics),
+    )
+
+    def _capture_message(message: str) -> None:
+        messages.append(message)
+
+    monkeypatch.setattr(agent.log, "info", _capture_message)
+
+    phase_times: dict[str, float] = {}
+    with agent._profile_iteration_phase(phase_times, "learn/policy_updates"):
+        pass
+    with agent._profile_iteration_phase(phase_times, "learn/policy_updates"):
+        pass
+    assert len(sync_calls) == 4
+    assert phase_times["learn/policy_updates"] >= 0.0
+
+    iteration = IterationData(
+        iteration_idx=0,
+        frames=8,
+        phase_times={
+            "collect": 0.4,
+            "prepare": 0.1,
+            "learn": 0.3,
+            "record": 0.2,
+            **phase_times,
+        },
+    )
+    metadata = TrainingMetadata(total_iterations=1, frames_processed=8)
+    agent._finish_iteration_profile(metadata, iteration)
+
+    assert logged_metrics["profile/total_s"] == pytest.approx(1.0)
+    assert logged_metrics["profile/frames_per_second"] == pytest.approx(8.0)
+    assert logged_metrics["profile/learn/policy_updates_s"] >= 0.0
+    assert messages
+    assert "iteration_profile | iter=1/1" in messages[0]
+    agent.collector.shutdown()
+
+
 def test_ipmd_reward_next_obs_requires_aligned_expert_transitions() -> None:
     """Reward next-state expert inputs should fail fast without aligned transitions."""
     rlopt = _rlopt()

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -1867,6 +1867,66 @@ def test_fsq_quantizer_uses_all_even_level_codes() -> None:
     assert torch.equal(torch.unique(code), torch.arange(8))
 
 
+def test_fsq_quantizer_large_space_uses_per_coordinate_indices() -> None:
+    """SONIC's 32**64 space must not overflow a flat int64 code."""
+    from rlopt.agent.imitation.latent_learning import FSQQuantizer
+
+    quantizer = FSQQuantizer([32] * 64)
+    z_e = torch.randn(4, 64)
+    z_q, code, _ = quantizer(z_e)
+
+    assert quantizer.codebook_size == 32**64
+    assert quantizer.usage_vocab_size == 32
+    assert quantizer.flat_code_supported is False
+    assert code.shape == (4, 64)
+    assert torch.equal(quantizer.indices_to_codes(code), z_q.detach())
+
+
+def test_patch_vqvae_large_normalized_fsq_updates_without_flat_code() -> None:
+    """The official 64x32 normalized posterior must train without overflow."""
+    rlopt = _rlopt()
+    from rlopt.agent.imitation.latent_learning import PatchVQVAELatentLearner
+
+    cfg = rlopt.IPMDRLOptConfig()
+    cfg.ipmd.latent_dim = 64
+    cfg.ipmd.latent_learning.method = "patch_vqvae"
+    cfg.ipmd.latent_learning.quantizer = "fsq"
+    cfg.ipmd.latent_learning.fsq_levels = [32] * 64
+    cfg.ipmd.latent_learning.fsq_normalize_codes = True
+    cfg.ipmd.latent_learning.code_latent_dim = 64
+    cfg.ipmd.latent_learning.posterior_input_keys = ["window"]
+    cfg.ipmd.latent_learning.encoder_hidden_dims = [16]
+    cfg.ipmd.latent_learning.decoder_hidden_dims = [16]
+    cfg.ipmd.latent_learning.recon_coeff = 0.01
+    cfg.ipmd.expert_batch_size = 4
+    cfg.ipmd.validate()
+
+    expert_data = TensorDict({"window": torch.randn(4, 30)}, batch_size=[4])
+
+    def _next_expert_batch(batch_size=4, *, required_keys):
+        return expert_data[:batch_size].select(*required_keys).clone()
+
+    fake_agent = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _latent_dim=64,
+        _obs_feature_dims={"window": 30},
+        _posterior_obs_keys=["window"],
+        _action_feature_dim=2,
+        _next_expert_batch=_next_expert_batch,
+    )
+    learner = PatchVQVAELatentLearner()
+    learner.initialize(fake_agent)
+    command = learner.infer_batch_latents(expert_data, detach=True, context="test")
+    metrics = learner.update(TensorDict({}, batch_size=[0]))
+
+    assert command is not None
+    assert bool((command.abs() <= 1.0 + 1e-6).all())
+    assert torch.allclose(command * 16, (command * 16).round(), atol=1e-5)
+    assert metrics["ipmd/vqvae_codebook_size"] == float(32**64)
+    assert 0.0 <= metrics["ipmd/vqvae_dead_codes"] <= 32.0
+
+
 def test_patch_vqvae_collector_holds_code_and_reports_phase() -> None:
     """The collector hook should hold z_q while sin/cos phase advances."""
     rlopt = _rlopt()

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -1425,6 +1425,80 @@ def test_ipmd_update_with_expert_data():
         assert not torch.isinf(value).any(), f"Inf in {key}"
 
 
+def test_ipmd_backward_ppo_terms_skips_latent_update_when_no_renewals() -> None:
+    """An all-False renewal mask must not reach the posterior latent learner.
+
+    Regression test: ``TensorDict.numel()`` is lower-bounded to 1 by design
+    (its own docstring notes an empty-shape stack still counts as 1 element),
+    so guarding on ``posterior_batch.numel() > 0`` can never detect an
+    empty-mask selection. Before the fix, a minibatch whose sin/cos phase
+    never hits the renewal condition crashed inside
+    ``_patch_features_from_td`` trying to reshape a 0-length tensor.
+    """
+    rlopt = _rlopt()
+    cfg = rlopt.IPMDRLOptConfig()
+    cfg.env.env_name = "Pendulum-v1"
+    cfg.env.device = "cpu"
+    cfg.device = "cpu"
+    cfg.collector.frames_per_batch = 4
+    cfg.collector.total_frames = 4
+    cfg.replay_buffer.size = 64
+    cfg.loss.mini_batch_size = 4
+    cfg.compile.compile = False
+    cfg.ipmd.reward_num_cells = (32, 32)
+    cfg.ipmd.expert_batch_size = 4
+    _apply_obs_input_keys(cfg)
+    cfg.ipmd.latent_learning.train_posterior_through_policy = True
+    cfg.ipmd.latent_learning.command_phase_mode = "sin_cos"
+    cfg.ipmd.latent_learning.code_period = 4
+
+    env = rlopt.make_parallel_env(cfg)
+    agent = rlopt.IPMD(env, cfg, logger=None)
+
+    expert_data = create_synthetic_expert_data(env, num_transitions=50)
+    agent._set_test_expert_batch_sampler(_make_test_expert_sampler(expert_data))
+
+    obs_dim = env.observation_spec["observation"].shape[-1]
+    act_dim = env.action_spec.shape[-1]
+    batch_size = 4
+
+    observation = torch.randn(batch_size, obs_dim)
+    # latent_key == "observation" in this fixture; pin the phase (last two
+    # components) far from the renewal condition (phase ~= [0, 1]) for every
+    # row so the renewal mask is all-False.
+    observation[:, -2:] = torch.tensor([1.0, 0.0])
+
+    policy_batch = TensorDict(
+        {
+            "observation": observation,
+            "action": torch.randn(batch_size, act_dim),
+            "action_log_prob": torch.zeros(batch_size),
+            ("next", "observation"): torch.randn(batch_size, obs_dim),
+            ("next", "reward"): torch.randn(batch_size, 1),
+            ("next", "done"): torch.zeros(batch_size, 1, dtype=torch.bool),
+            ("next", "terminated"): torch.zeros(batch_size, 1, dtype=torch.bool),
+            ("next", "truncated"): torch.zeros(batch_size, 1, dtype=torch.bool),
+        },
+        batch_size=[batch_size],
+    )
+    with torch.no_grad():
+        policy_batch = agent.adv_module(policy_batch)
+
+    num_network_updates = torch.zeros((), dtype=torch.int64, device=agent.device)
+    expert_batch = agent._next_expert_batch(batch_size=cfg.ipmd.expert_batch_size)
+    has_expert = torch.tensor(1.0, device=agent.device, dtype=torch.float32)
+    loss_td, _ = agent.update(
+        policy_batch, num_network_updates, expert_batch, has_expert
+    )
+
+    assert "loss_critic" in loss_td
+    assert "loss_objective" in loss_td
+    for key in tuple(loss_td.keys()):
+        value = loss_td[key]
+        assert not torch.isnan(value).any(), f"NaN in {key}"
+        assert not torch.isinf(value).any(), f"Inf in {key}"
+
+
 def test_ipmd_bc_pretrain_updates_skip_then_restore_ppo() -> None:
     """BC pretraining should suppress PPO gradients only for its fixed prefix."""
     rlopt = _rlopt()

--- a/tests/test_ipmd_components.py
+++ b/tests/test_ipmd_components.py
@@ -139,6 +139,91 @@ def test_ipmd_split_actor_critic_learning_rates_and_adaptation():
         env.close()
 
 
+def test_kl_adapt_step_update_moves_lr_on_every_minibatch():
+    """The historical default: one bang-bang step per recorded KL sample."""
+    agent, env = _make_env_reward_only_ipmd_agent(split_actor_critic_lr=True)
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        assert agent.config.optim.kl_adapt_step == "update"
+
+        for _ in range(2):
+            agent._record_kl_for_lr_adaptation(torch.tensor(1.0e-4), agent.config.optim)
+
+        # Two sub-target samples, two multiplications: 2e-5 -> 3e-5 -> 4.5e-5.
+        assert groups["actor"]["lr"] == pytest.approx(4.5e-5)
+
+        # Nothing was buffered, so a flush cannot move the LR again.
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(4.5e-5)
+    finally:
+        env.close()
+
+
+def test_kl_adapt_step_iteration_applies_exactly_one_step_per_flush():
+    agent, env = _make_env_reward_only_ipmd_agent(split_actor_critic_lr=True)
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        agent.config.optim.kl_adapt_step = "iteration"
+
+        for _ in range(5):
+            agent._record_kl_for_lr_adaptation(torch.tensor(1.0e-4), agent.config.optim)
+        # Buffered, not applied: five minibatches must not move the LR five times.
+        assert groups["actor"]["lr"] == pytest.approx(2.0e-5)
+
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(3.0e-5)
+
+        # The buffer is consumed, so a second flush is a no-op.
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(3.0e-5)
+    finally:
+        env.close()
+
+
+def test_kl_adapt_step_iteration_uses_the_mean_not_each_sample():
+    """Samples that straddle the dead band average into it and cancel.
+
+    Under ``"update"`` the same pair would fire once (0.001 is below
+    ``desired_kl / 2``) and raise the LR; the point of ``"iteration"`` is that
+    the rule sees the iteration's mean KL instead.
+    """
+    agent, env = _make_env_reward_only_ipmd_agent(split_actor_critic_lr=True)
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        agent.config.optim.kl_adapt_step = "iteration"
+
+        for sample in (0.001, 0.019):  # mean 0.01 == desired_kl, inside the band
+            agent._record_kl_for_lr_adaptation(torch.tensor(sample), agent.config.optim)
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+
+        assert groups["actor"]["lr"] == pytest.approx(2.0e-5)
+    finally:
+        env.close()
+
+
+def test_kl_adapt_step_iteration_drops_non_finite_samples():
+    agent, env = _make_env_reward_only_ipmd_agent(split_actor_critic_lr=True)
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        agent.config.optim.kl_adapt_step = "iteration"
+
+        agent._record_kl_for_lr_adaptation(
+            torch.tensor(float("nan")), agent.config.optim
+        )
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(2.0e-5)
+
+        # A finite sample alongside the dropped one still adapts on its own.
+        agent._record_kl_for_lr_adaptation(
+            torch.tensor(float("inf")), agent.config.optim
+        )
+        agent._record_kl_for_lr_adaptation(torch.tensor(1.0e-4), agent.config.optim)
+        agent._flush_kl_lr_adaptation(agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(3.0e-5)
+    finally:
+        env.close()
+
+
 def test_ipmd_split_learning_rates_must_be_configured_together():
     cfg = _rlopt().IPMDRLOptConfig()
     cfg.ipmd.actor_learning_rate = 2.0e-5

--- a/tests/test_ipmd_l2t.py
+++ b/tests/test_ipmd_l2t.py
@@ -1,0 +1,342 @@
+"""Focused tests for privileged-teacher IPMD distillation."""
+
+from __future__ import annotations
+
+import warnings
+from functools import lru_cache
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+
+@lru_cache(maxsize=1)
+def _rlopt() -> SimpleNamespace:
+    warnings.filterwarnings(
+        "ignore",
+        message="Creating .* which inherits from WeightUpdaterBase is deprecated.*",
+        category=DeprecationWarning,
+        append=False,
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=(
+            "`torch.jit.script_method` is deprecated. Please switch to "
+            "`torch.compile` or `torch.export`."
+        ),
+        category=DeprecationWarning,
+    )
+    from rlopt.agent import IPMD, IPMDL2T, IPMDL2TRLOptConfig
+    from rlopt.agent.ipmd.ipmd import IPMD as IPMDBase
+    from rlopt.env_utils import make_parallel_env
+
+    return SimpleNamespace(
+        IPMD=IPMD,
+        IPMDBase=IPMDBase,
+        IPMDL2T=IPMDL2T,
+        IPMDL2TRLOptConfig=IPMDL2TRLOptConfig,
+        make_parallel_env=make_parallel_env,
+    )
+
+
+def _config(*, split_learning_rates: bool = True):
+    cfg = _rlopt().IPMDL2TRLOptConfig()
+    cfg.env.env_name = "Pendulum-v1"
+    cfg.env.device = "cpu"
+    cfg.device = "cpu"
+    cfg.collector.frames_per_batch = 4
+    cfg.collector.total_frames = 4
+    cfg.replay_buffer.size = 64
+    cfg.loss.mini_batch_size = 4
+    cfg.compile.compile = False
+    cfg.logger.backend = ""
+    cfg.policy.input_keys = ["observation"]
+    assert cfg.value_function is not None
+    cfg.value_function.input_keys = ["observation"]
+    cfg.ipmd_l2t.student_policy.input_keys = ["observation"]
+    cfg.ipmd.use_latent_command = False
+    cfg.ipmd.reward_input_keys = ["observation"]
+    cfg.ipmd.reward_loss_coeff = 0.0
+    cfg.ipmd.reward_l2_coeff = 0.0
+    cfg.ipmd.reward_grad_penalty_coeff = 0.0
+    cfg.ipmd.reward_logit_reg_coeff = 0.0
+    cfg.ipmd.reward_param_weight_decay_coeff = 0.0
+    cfg.ipmd.bc_coef = 0.0
+    cfg.ipmd.rollout_bc_coef = 0.0
+    cfg.ipmd.diversity_bonus_coeff = 0.0
+    cfg.optim.max_grad_norm = 0.5
+    cfg.ipmd_l2t.student_max_grad_norm = 0.25
+    if split_learning_rates:
+        cfg.ipmd.actor_learning_rate = 2.0e-5
+        cfg.ipmd.critic_learning_rate = 1.0e-3
+        cfg.optim.scheduler = "adaptive"
+        cfg.optim.min_lr = 1.0e-5
+        cfg.optim.max_lr = 2.0e-4
+    return cfg
+
+
+def _make_agent(*, split_learning_rates: bool = True):
+    rlopt = _rlopt()
+    cfg = _config(split_learning_rates=split_learning_rates)
+    env = rlopt.make_parallel_env(cfg)
+    return rlopt.IPMDL2T(env, cfg, logger=None), env
+
+
+def _policy_batch(agent, batch_size: int = 4) -> TensorDict:
+    obs_dim = agent.env.observation_spec["observation"].shape[-1]
+    act_dim = agent.env.action_spec.shape[-1]
+    batch = TensorDict(
+        {
+            "observation": torch.randn(batch_size, obs_dim),
+            "action": torch.tanh(torch.randn(batch_size, act_dim)),
+            "action_log_prob": torch.zeros(batch_size),
+            ("next", "observation"): torch.randn(batch_size, obs_dim),
+            ("next", "reward"): torch.randn(batch_size, 1),
+            ("next", "done"): torch.zeros(batch_size, 1, dtype=torch.bool),
+            ("next", "terminated"): torch.zeros(batch_size, 1, dtype=torch.bool),
+            ("next", "truncated"): torch.zeros(batch_size, 1, dtype=torch.bool),
+        },
+        batch_size=[batch_size],
+    )
+    with torch.no_grad():
+        return agent.adv_module(batch)
+
+
+def _state_dict_clone(module) -> dict[str, torch.Tensor]:
+    return {key: value.detach().clone() for key, value in module.state_dict().items()}
+
+
+def _assert_state_dict_equal(module, expected: dict[str, torch.Tensor]) -> None:
+    actual = module.state_dict()
+    assert actual.keys() == expected.keys()
+    for key, value in expected.items():
+        assert torch.equal(actual[key], value), key
+
+
+def test_collection_is_teacher_only_and_student_is_deployment_policy() -> None:
+    agent, env = _make_agent()
+    try:
+        collector_param_ids = {
+            id(param) for param in agent.collector_policy.parameters()
+        }
+        teacher_param_ids = {id(param) for param in agent.teacher_policy.parameters()}
+        student_param_ids = {id(param) for param in agent.student_policy.parameters()}
+        assert collector_param_ids == teacher_param_ids
+        assert collector_param_ids.isdisjoint(student_param_ids)
+        assert agent.deployment_policy is agent.student_policy
+        assert agent.teacher_policy is not agent.student_policy
+        assert agent._student_obs_keys == ["observation"]
+        monitored_ids = {id(param) for _, param in agent._parameter_monitor}
+        assert {id(param) for param in agent.student_policy.parameters()}.issubset(
+            monitored_ids
+        )
+    finally:
+        env.close()
+
+
+def test_teacher_keys_must_exactly_match_critic_keys() -> None:
+    rlopt = _rlopt()
+    cfg = _config()
+    env = rlopt.make_parallel_env(cfg)
+    try:
+        assert cfg.value_function is not None
+        cfg.value_function.input_keys = [("critic", "privileged")]
+        with pytest.raises(ValueError, match="exactly match"):
+            rlopt.IPMDL2T(env, cfg, logger=None)
+    finally:
+        env.close()
+
+
+def test_student_architecture_must_match_teacher_actor() -> None:
+    rlopt = _rlopt()
+    cfg = _config()
+    cfg.ipmd_l2t.student_policy.num_cells = [32, 32]
+    env = rlopt.make_parallel_env(cfg)
+    try:
+        with pytest.raises(ValueError, match="match the teacher actor architecture"):
+            rlopt.IPMDL2T(env, cfg, logger=None)
+    finally:
+        env.close()
+
+
+def test_student_backward_detaches_teacher_action_and_stops_teacher_gradients() -> None:
+    agent, env = _make_agent()
+    try:
+        obs_dim = env.observation_spec["observation"].shape[-1]
+        act_dim = env.action_spec.shape[-1]
+        target = torch.randn(4, act_dim, requires_grad=True)
+        observation = torch.randn(4, obs_dim, requires_grad=True)
+        batch = TensorDict(
+            {
+                "observation": observation,
+                "action": target,
+            },
+            batch_size=[4],
+        )
+        teacher_before = _state_dict_clone(agent.teacher_policy)
+        student_before = _state_dict_clone(agent.student_policy)
+
+        agent.optim.zero_grad(set_to_none=True)
+        metrics = agent._backward_student_imitation(batch)
+
+        assert target.grad is None
+        assert observation.grad is None
+        assert all(param.grad is None for param in agent.teacher_policy.parameters())
+        assert any(
+            param.grad is not None for param in agent.student_policy.parameters()
+        )
+        assert all(torch.isfinite(value) for value in metrics.values())
+
+        agent.optim.step()
+        _assert_state_dict_equal(agent.teacher_policy, teacher_before)
+        assert any(
+            not torch.equal(value, student_before[key])
+            for key, value in agent.student_policy.state_dict().items()
+        )
+    finally:
+        env.close()
+
+
+def test_student_optimizer_is_nonadaptive_and_parameter_sets_are_disjoint() -> None:
+    agent, env = _make_agent()
+    try:
+        groups = {group["name"]: group for group in agent.optim.param_groups}
+        assert groups["actor"]["lr"] == pytest.approx(2.0e-5)
+        assert groups["critic"]["lr"] == pytest.approx(1.0e-3)
+        assert groups["student"]["lr"] == pytest.approx(2.0e-5)
+        assert groups["student"]["adaptive_lr"] is False
+
+        teacher_ids = {id(param) for param in agent._grad_clip_params}
+        student_ids = {id(param) for param in agent._student_grad_clip_params}
+        assert teacher_ids
+        assert student_ids
+        assert teacher_ids.isdisjoint(student_ids)
+
+        agent._maybe_adjust_lr(torch.tensor(1.0e-4), agent.config.optim)
+        assert groups["actor"]["lr"] == pytest.approx(3.0e-5)
+        assert groups["critic"]["lr"] == pytest.approx(1.0e-3)
+        assert groups["student"]["lr"] == pytest.approx(2.0e-5)
+    finally:
+        env.close()
+
+
+def test_update_clips_roles_separately_and_emits_finite_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent, env = _make_agent()
+    calls: list[tuple[set[int], float]] = []
+    import rlopt.agent.ipmd.ipmd_l2t as l2t_module
+
+    original_clip = l2t_module.clip_grad_norm_
+
+    def _recording_clip(parameters, max_norm):
+        params = list(parameters)
+        calls.append(({id(param) for param in params}, float(max_norm)))
+        return original_clip(params, max_norm)
+
+    monkeypatch.setattr(l2t_module, "clip_grad_norm_", _recording_clip)
+    try:
+        student_before = _state_dict_clone(agent.student_policy)
+        batch = _policy_batch(agent)
+        loss, update_idx = agent.update(
+            batch,
+            0,
+            TensorDict({}, batch_size=[4]),
+            torch.tensor(0.0),
+        )
+
+        assert update_idx == 1
+        assert len(calls) == 2
+        assert calls[0][0] == {id(param) for param in agent._grad_clip_params}
+        assert calls[0][1] == pytest.approx(0.5)
+        assert calls[1][0] == {id(param) for param in agent._student_grad_clip_params}
+        assert calls[1][1] == pytest.approx(0.25)
+        for key in (
+            "loss_student_imitation",
+            "student_action_mae",
+            "student_action_rmse",
+            "student_action_abs_mean",
+            "teacher_action_abs_mean",
+            "student_grad_norm",
+        ):
+            assert key in loss
+            assert torch.isfinite(loss[key])
+        assert any(
+            not torch.equal(value, student_before[key])
+            for key, value in agent.student_policy.state_dict().items()
+        )
+    finally:
+        env.close()
+
+
+def test_latent_command_is_mirrored_tensor_identically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rlopt = _rlopt()
+    teacher_key = ("critic", "latent_command")
+    student_key = ("policy", "latent_command")
+    latent = torch.randn(3, 8)
+
+    def _fake_teacher_injection(self, td):
+        td.set(self._latent_key, latent)
+
+    monkeypatch.setattr(
+        rlopt.IPMDBase,
+        "_inject_latent_command",
+        _fake_teacher_injection,
+    )
+    agent = object.__new__(rlopt.IPMDL2T)
+    agent._use_latent_command = True
+    agent._latent_key = teacher_key
+    agent._student_latent_key = student_key
+    td = TensorDict({}, batch_size=[3])
+
+    rlopt.IPMDL2T._inject_latent_command(agent, td)
+
+    teacher_value = td.get(teacher_key)
+    student_value = td.get(student_key)
+    assert isinstance(teacher_value, torch.Tensor)
+    assert isinstance(student_value, torch.Tensor)
+    assert torch.equal(teacher_value, student_value)
+    assert teacher_value.data_ptr() == student_value.data_ptr()
+
+
+def test_checkpoint_round_trip_and_standard_ipmd_deployment_load(tmp_path) -> None:
+    rlopt = _rlopt()
+    agent, env = _make_agent()
+    restored = ordinary = None
+    restored_env = ordinary_env = None
+    try:
+        student_state = _state_dict_clone(agent.student_policy)
+        teacher_state = _state_dict_clone(agent.teacher_policy)
+        checkpoint_path = tmp_path / "ipmd_l2t.pt"
+        agent.save_model(checkpoint_path)
+        payload = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        assert payload["checkpoint_metadata"] == {
+            "algorithm": "IPMD_L2T",
+            "primary_policy_role": "student",
+        }
+        assert "teacher_policy_state_dict" in payload
+
+        restored_cfg = _config()
+        restored_env = rlopt.make_parallel_env(restored_cfg)
+        restored = rlopt.IPMDL2T(restored_env, restored_cfg, logger=None)
+        restored.load_model(str(checkpoint_path))
+        _assert_state_dict_equal(restored.student_policy, student_state)
+        _assert_state_dict_equal(restored.teacher_policy, teacher_state)
+
+        ordinary_cfg = _config()
+        ordinary_env = rlopt.make_parallel_env(ordinary_cfg)
+        ordinary = rlopt.IPMD(ordinary_env, ordinary_cfg, logger=None)
+        ordinary.load_model(str(checkpoint_path))
+        _assert_state_dict_equal(ordinary.policy, student_state)
+
+        plain_path = tmp_path / "ordinary_ipmd.pt"
+        torch.save({"policy_state_dict": teacher_state}, plain_path)
+        with pytest.raises(ValueError, match="teacher_policy_state_dict"):
+            restored.load_model(str(plain_path))
+    finally:
+        for close_env in (ordinary_env, restored_env, env):
+            if close_env is not None:
+                close_env.close()


### PR DESCRIPTION
Accumulated RLOpt work behind the IsaacLab-Imitation v2 command interface. Merges current `main` (`b7d529c`) and completes its integration.

`pixi run test-rlopt`: **121 passed**.

## Optimizer

**`optim.kl_adapt_step: "update" | "iteration"`** — the adaptive-KL learning-rate rule was invoked after *every minibatch*, 80 times per iteration at 12288×24. Measured over 10,000 logged points of a 3.5B-frame run, the iteration-mean KL sat inside the rule's dead band **100% of the time**, so evaluated once per iteration it would never have fired: every LR movement came from per-minibatch sampling noise, producing a zero-drift random walk ~30× below the configured `lr`. Defaults to `"update"`, so existing runs stay bit-identical.

This was the single largest contributor to the downstream 4.6× return/min tuning result.

## Env boundary

**`rlopt/env_interface.py`** — one `ImitationEnvInterface` replacing `getattr`-discovered methods, plus an `ExpertProvider` protocol and `require_env_method` loud discovery. A missing env method now fails at wiring time with a name, instead of silently degrading at some later step.

## Agents

- IPMD with privileged teacher / student actor.
- Fix: IPMD posterior-mode crash when a PPO minibatch contains zero renewals.
- `hl_skill`: forward the phi parameterization to the SR module.
- Per-phase iteration profiling with timing synchronization, reported across algorithms.

## Skill encoders

- `SONICFSQSkillEncoder` — normalized lattice codes in `[-1, 1]` and an identity `code_to_latent`, so the planner→tracker interface is *actually* quantized rather than merely trained through a quantizer. `FSQSkillEncoder` projects to `z_dim` before the command boundary, which leaves every point in R^z_dim admissible.
- FSQ quantizer support for large spaces (SONIC's 64×32 lattice is 2^320, well past int64).

## Integrating main

`b7d529c` added `report_flat_code_metrics` and `MultiCategoricalSkillEncoder.diversity_metrics`. The textual merge was clean but **incomplete**: that flag gates flat-codebook statistics because multi-categorical codes are per-group indices, not a flat index. Both FSQ encoders take the same no-flat-index path whenever the level product overflows int64 — where `num_codes` falls back to `max(levels)` and the old guard `0 < num_codes <= 1 << 16` *passes* on that fallback, reporting a perplexity that bincounts per-dimension indices pooled across all dimensions. Meaningless, and SONIC's default lattice always lands there.

Now derived from `fsq.flat_code_supported`, so a genuinely small FSQ config keeps the metric.

## Logging

Bug fix: TorchRL's `get_logger` routes file-backed loggers by `logger_name` and ignores `log_dir`, so `logger.backend=csv` wrote scalars to `./ipmd/` beside the process CWD rather than the configured run directory.

## Companion

Paired with IsaacLab-Imitation PR #28. The submodule pointer there already tracks this branch.